### PR TITLE
Fix for #3 Switch content-type map key to string to fix form login.

### DIFF
--- a/src/clauth/middleware.clj
+++ b/src/clauth/middleware.clj
@@ -64,7 +64,7 @@
   "returns true if request has text/html in the accept header"
   [req]
   (if (or (not (:access-token req)) (and (:access-token req) (:access_token (req :session {}))))
-    (if-let [content-type (req :content-type)]
+    (if-let [content-type (req "content-type")]
       (if (seq (filter (partial  = content-type) ["application/x-www-form-urlencoded" "multipart/form-data"])) true))))
 
   


### PR DESCRIPTION
This change gets the demo login page working for me. I don't know if it's the correct approach though.
