### PR TITLE
Clojure conventions, idioms, and best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a simple OAuth 2 provider that is designed to be used as a primary authentication provider for a Clojure Ring app.
 
-It currently handles OAuth2 bearer authentication and interactive authentication. 
+It currently handles OAuth2 bearer authentication and interactive authentication.
 
 See [draft-ietf-oauth-v2-bearer](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08)
 
@@ -45,7 +45,7 @@ Currently the following Grant types are supported:
 * [Client Credential Grant](http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.4)
 * [Resource Owner Password Credential Grant](http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.3)
 
-Grant types are implemented using multimethods. To implement one 
+Grant types are implemented using multimethods. To implement one
 
 ```clojure
 (defmethod token-request-handler "my_grant_type" [req authenticator] ...)
@@ -98,7 +98,7 @@ Stores are used to store tokens and will be used to store clients and users as w
 
 There is a generalized protocol called Store and currently a simple memory implementation used for it.
 
-It should be pretty simple to implement this Store with redis, sql, datomic or what have you. 
+It should be pretty simple to implement this Store with redis, sql, datomic or what have you.
 
 It includes a simple Redis implementation.
 
@@ -120,7 +120,7 @@ To use the redis store add the following to your code:
 (reset! user-store (create-redis-store "users"))
 ```
 
-And wrap your handler with a redis connection middleware similar to this: 
+And wrap your handler with a redis connection middleware similar to this:
 
 ```clojure
 (defn wrap-redis-store [app]
@@ -135,12 +135,12 @@ And wrap your handler with a redis connection middleware similar to this:
 
 ## Authorization OAuth Tokens
 
-There is currently a single authorization-handler that handles authorization called authorization-handler. Install it in your routes by convention at "/authorize" or "/oauth/authorize". 
+There is currently a single authorization-handler that handles authorization called authorization-handler. Install it in your routes by convention at "/authorize" or "/oauth/authorize".
 
 ```clojure
 (defn routes [req]
   (case (req :uri)
-    "/authorize" ((authorization-handler) req )
+    "/authorize" ((authorization-handler) req)
     ((require-bearer-token! handler) req)))
 ```
 
@@ -150,28 +150,28 @@ Authorization handler comes with defaults that use the various built in token, u
 (authorization-handler {:authorization-form authorization-form-handler
                         :client-lookup clauth.client/fetch-client
                         :token-lookup clauth.token/fetch-token
-                        :token-creator clauth.token/create-token 
+                        :token-creator clauth.token/create-token
                         :auth-code-creator clauth.auth-code/create-auth-code})
 ```
 
 ## Issuing OAuth Tokens
 
-There is currently a single token-handler that provides token issuance called token-handler. Install it in your routes by convention at "/token" or "/oauth/token". 
+There is currently a single token-handler that provides token issuance called token-handler. Install it in your routes by convention at "/token" or "/oauth/token".
 
 ```clojure
 (defn routes [req]
   (case (req :uri)
-    "/token" ((token-handler) req )
+    "/token" ((token-handler) req)
     ((require-bearer-token! handler) req)))
 ```
 
 Token handler comes with defaults that use the various built in token, user etc. stores. You can override these by passing in a configuration map containing functions.
 
 ```clojure
-(token-handler {:client-authenticator clauth.client/authenticate-client 
+(token-handler {:client-authenticator clauth.client/authenticate-client
                 :user-authenticator clauth.user/authenticate-user
                 :token-creator clauth.token/create-token
-                :auth-code-revoker clauth.auth-code/revoke-auth-code! 
+                :auth-code-revoker clauth.auth-code/revoke-auth-code!
                 :auth-code-lookup clauth.auth-code/fetch-auth-code })
 ```
 
@@ -191,7 +191,7 @@ To use this make sure to wrap the session middleware. We have a login handler en
 (defn routes [master-client]
   (fn [req]
   (case (req :uri)
-    "/login" ((login-handler master-client) req )
+    "/login" ((login-handler master-client) req)
     ((require-bearer-token! handler) req))))
 ```
 
@@ -201,7 +201,7 @@ The master-client is a client record representing your own application. A defaul
 (defn routes [master-client]
   (fn [req]
   (case (req :uri)
-    "/login" ((login-handler my-own-login-form-handler master-client) req )
+    "/login" ((login-handler my-own-login-form-handler master-client) req)
     ((require-bearer-token! handler) req))))
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,7 @@
 (defproject clauth "1.0.0-rc10"
   :description "OAuth2 based authentication library for Ring"
   :url "http://github.com/pelle/clauth"
-
-  :dependencies [[org.clojure/clojure "1.4.0"] 
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [crypto-random "1.1.0"]
                  [commons-codec "1.6"]
                  [ring/ring-core "1.1.0"]
@@ -10,10 +9,8 @@
                  [clj-time "0.3.7"]
                  [org.mindrot/jbcrypt "0.3m"]
                  [hiccup "1.0.0"]]
-
   :dev-dependencies [[ring/ring-jetty-adapter "1.1.0"]
                      [lein-marginalia "0.7.0"]
                      [org.clojars.tavisrudd/redis-clojure "1.3.1"]
                      [hiccup-bootstrap "0.1.0"]]
-  :clean-non-project-classes true )
- 
+  :clean-non-project-classes true)

--- a/src/clauth/auth_code.clj
+++ b/src/clauth/auth_code.clj
@@ -1,6 +1,7 @@
 (ns clauth.auth-code
-  (:require [clauth.store :as store]
-            [clauth.token :as token]
+  (:require [clauth
+             [store :as store]
+             [token :as token]]
             [clj-time.core :as time]))
 
 (defrecord OAuthCode [code client subject redirect-uri expires scope object])

--- a/src/clauth/client.clj
+++ b/src/clauth/client.clj
@@ -1,9 +1,8 @@
 (ns clauth.client
-  (:use [clauth.token]
-        [clauth.store])
-  (:require [cheshire.core]))
+  (:require [clauth.token :refer [generate-token]]
+            [clauth.store :as store]))
 
-(defonce client-store (atom (create-memory-store)))
+(defonce client-store (atom (store/create-memory-store)))
 
 (defrecord ClientApplication [client-id client-secret name url])
 
@@ -24,22 +23,22 @@
 (defn reset-client-store!
   "mainly for used in testing. Clears out all clients."
   []
-  (reset-store! @client-store))
+  (store/reset-store! @client-store))
 
 (defn fetch-client
   "Find OAuth token based on the id string"
   [t]
-  (client-app (fetch @client-store t)))
+  (client-app (store/fetch @client-store t)))
 
 (defn store-client
   "Store the given ClientApplication and return it."
   [t]
-  (store! @client-store :client-id t))
+  (store/store! @client-store :client-id t))
 
 (defn clients
   "Sequence of clients"
   []
-  (entries @client-store))
+  (store/entries @client-store))
 
 (defn register-client
   "create a unique client and store it in the client store"

--- a/src/clauth/client.clj
+++ b/src/clauth/client.clj
@@ -1,25 +1,26 @@
 (ns clauth.client
-    (:use [clauth.token]
-          [clauth.store])
-    (:require [cheshire.core]))
-
+  (:use [clauth.token]
+        [clauth.store])
+  (:require [cheshire.core]))
 
 (defonce client-store (atom (create-memory-store)))
 
-(defrecord ClientApplication
-  [client-id client-secret name url])
+(defrecord ClientApplication [client-id client-secret name url])
 
 (defn client-app
   "Create new client-application record"
   ([attrs] ; Swiss army constructor. There must be a better way.
-    (cond
+     (cond
       (nil? attrs) nil
       (instance? ClientApplication attrs) attrs
-      (instance? java.lang.String attrs) (client-app (cheshire.core/parse-string attrs true))
-      :default (ClientApplication. (attrs :client-id) (attrs :client-secret) (attrs :name) (attrs :url))))
+      (instance? java.lang.String attrs) (client-app
+                                          (cheshire.core/parse-string
+                                           attrs true))
+      :default (ClientApplication. (attrs :client-id) (attrs :client-secret)
+                                   (attrs :name) (attrs :url))))
   ([] (client-app nil nil))
   ([name url] (ClientApplication. (generate-token) (generate-token) name url)))
-  
+
 (defn reset-client-store!
   "mainly for used in testing. Clears out all clients."
   []
@@ -40,17 +41,16 @@
   []
   (entries @client-store))
 
-(defn register-client 
+(defn register-client
   "create a unique client and store it in the client store"
   ([] (register-client nil nil))
-  ([ name url ]
-    (let [client (client-app name url)]
-      (store-client client))))
+  ([name url]
+     (let [client (client-app name url)]
+       (store-client client))))
 
 (defn authenticate-client
   "authenticate client application using client_id and client_secret"
   [client-id client-secret]
-  (if-let [ client (fetch-client client-id)]
+  (if-let [client (fetch-client client-id)]
     (if (= client-secret (:client-secret client))
-      client
-    )))
+      client)))

--- a/src/clauth/client.clj
+++ b/src/clauth/client.clj
@@ -1,6 +1,7 @@
 (ns clauth.client
-  (:require [clauth.token :refer [generate-token]]
-            [clauth.store :as store]))
+  (:require [clauth
+             [token :refer [generate-token]]
+             [store :as store]]))
 
 (defonce client-store (atom (store/create-memory-store)))
 

--- a/src/clauth/demo.clj
+++ b/src/clauth/demo.clj
@@ -1,21 +1,25 @@
 (ns clauth.demo
-  (:require [clauth.middleware :as mw]
-            [clauth.endpoints :as ep]
-            [clauth.client :refer [client-store clients register-client]]
-            [clauth.token :refer [token-store]]
-            [clauth.user :refer [user-store]]
-            [clauth.auth-code :refer [auth-code-store]]
-            [clauth.store.redis :refer [create-redis-store with-redis
-                                        wrap-redis]]
+  (:require [clauth
+             [middleware :as mw]
+             [endpoints :as ep]
+             [client :refer [client-store clients register-client]]
+             [token :refer [token-store]]
+             [user :refer [user-store]]
+             [auth-code :refer [auth-code-store]]]
+            [clauth.store.redis
+             :refer [create-redis-store with-redis wrap-redis]]
             [ring.adapter.jetty :refer [run-jetty]]
-            [ring.middleware.cookies :refer [wrap-cookies]]
-            [ring.middleware.session :refer [wrap-session]]
-            [ring.middleware.params :refer [wrap-params]]
-            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
-            [hiccup.bootstrap.middleware :refer [wrap-bootstrap-resources]]
-            [hiccup.bootstrap.page :refer [include-bootstrap fixed-layout]]
-            [hiccup.page :refer [html5]]
-            [hiccup.element :refer [link-to unordered-list]]))
+            [ring.middleware
+             [cookies :refer [wrap-cookies]]
+             [session :refer [wrap-session]]
+             [params :refer [wrap-params]]
+             [keyword-params :refer [wrap-keyword-params]]]
+            [hiccup.bootstrap
+             [middleware :refer [wrap-bootstrap-resources]]
+             [page :refer [include-bootstrap fixed-layout]]]
+            [hiccup
+             [page :refer [html5]]
+             [element :refer [link-to unordered-list]]]))
 
 (defn nav-menu [req]
   (if (ep/logged-in? req)

--- a/src/clauth/endpoints.clj
+++ b/src/clauth/endpoints.clj
@@ -1,10 +1,11 @@
 (ns clauth.endpoints
-  (:require [clauth.token :refer [create-token]]
-            [clauth.client :as client]
-            [clauth.user :as user]
-            [clauth.auth-code :refer [revoke-auth-code! fetch-auth-code]]
-            [clauth.middleware :as mw]
-            [clauth.views :as views]
+  (:require [clauth
+             [token :refer [create-token]]
+             [client :as client]
+             [user :as user]
+             [auth-code :refer [revoke-auth-code! fetch-auth-code]]
+             [middleware :as mw]
+             [views :as views]]
             [hiccup.util :refer [url-encode]]
             [ring.util.response :refer [redirect]]
             [cheshire.core :as cheshire])

--- a/src/clauth/endpoints.clj
+++ b/src/clauth/endpoints.clj
@@ -1,39 +1,38 @@
 (ns clauth.endpoints
-  (:use   [clauth.token]
-          [clauth.client]
-          [clauth.user]
-          [clauth.auth-code]
-          [clauth.middleware :only [csrf-protect! require-user-session!]]
-          [clauth.views :only [login-form-handler authorization-form-handler error-page]]
-          [hiccup.util :only [url-encode]]
-          [ring.util.response]
-          [cheshire.core])
+  (:use [clauth.token]
+        [clauth.client]
+        [clauth.user]
+        [clauth.auth-code]
+        [clauth.middleware :only [csrf-protect!
+                                  require-user-session!]]
+        [clauth.views :only [login-form-handler
+                             authorization-form-handler
+                             error-page]]
+        [hiccup.util :only [url-encode]]
+        [ring.util.response]
+        [cheshire.core])
   (:import [org.apache.commons.codec.binary Base64]))
 
-
-
-(defn decorate-token 
+(defn decorate-token
   "Take a token map and decorate it according to specs
 
-  http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-5.1"
+   http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-5.1"
   [token]
+  {:access_token (:token token) :token_type "bearer"})
 
-  { :access_token (:token token) :token_type "bearer"}
-  )
-
-(defn token-response 
+(defn token-response
   "Create a ring response for a token response"
   [token]
-  {  :status 200
-      :headers {"Content-Type" "application/json"}
-      :body (generate-string (decorate-token token))})
+  {:status 200
+   :headers {"Content-Type" "application/json"}
+   :body (generate-string (decorate-token token))})
 
-(defn error-response 
+(defn error-response
   "Create a ring response for a oauth error"
   [error]
-  {  :status 400
-      :headers {"Content-Type" "application/json"}
-      :body (generate-string {:error error })})
+  {:status 400
+   :headers {"Content-Type" "application/json"}
+   :body (generate-string {:error error})})
 
 (defn respond-with-new-token
   "create a new token and respond with json. If using built in token system it takes client and subject (user).
@@ -43,33 +42,35 @@
   ([token-creator client subject]
     (token-response (token-creator client subject))))
 
-(defn basic-authentication-credentials 
+(defn basic-authentication-credentials
   "decode basic authentication credentials.
 
    If it exists it returns a vector of username and password.
 
    If not nil."
   [req]
-  (if-let [ auth-string ((req :headers {}) "authorization")]
-    (if-let [ basic-token (last (re-find #"^Basic (.*)$" auth-string)) ]
-      (if-let [ credentials (String. (Base64/decodeBase64 basic-token))]
-        (clojure.string/split credentials #":" )
-      ))))
+  (if-let [auth-string ((req :headers {}) "authorization")]
+    (if-let [basic-token (last (re-find #"^Basic (.*)$" auth-string))]
+      (if-let [credentials (String. (Base64/decodeBase64 basic-token))]
+        (clojure.string/split credentials #":")))))
 
-(defn client-authenticated-request 
-  "Check that request is authenticated by client either using Basic authentication or url form encoded parameters.
+(defn client-authenticated-request
+  "Check that request is authenticated by client either using Basic
+   authentication or url form encoded parameters.
 
-   The client_id and client_secret are checked against the authenticate-client function.
+   The client_id and client_secret are checked against the authenticate-client
+   function.
 
-   If authenticate-client returns a client map it runs success function with the request and the client."
+   If authenticate-client returns a client map it runs success function with
+   the request and the client."
   [req authenticator success]
-  (let [ basic (basic-authentication-credentials req)
-         client_id (if basic (first basic) ((req :params ) :client_id))
-         client_secret (if basic (last basic) ((req :params) :client_secret))
-         client (authenticator client_id client_secret)]
-          (if client 
-            (success req client)
-            (error-response "invalid_client"))))
+  (let [basic (basic-authentication-credentials req)
+        client_id (if basic (first basic) ((req :params) :client_id))
+        client_secret (if basic (last basic) ((req :params) :client_secret))
+        client (authenticator client_id client_secret)]
+    (if client
+      (success req client)
+      (error-response "invalid_client"))))
 
 (defn grant-type
   "extract grant type from request"
@@ -77,37 +78,40 @@
 
 (defmulti token-request-handler grant-type)
 
-(defmethod token-request-handler "client_credentials" 
-  [req { :keys [client-authenticator token-creator]}]
-  (client-authenticated-request 
-    req 
-    client-authenticator
-    (fn [req client] (respond-with-new-token token-creator client client))))
+(defmethod token-request-handler "client_credentials"
+  [req {:keys [client-authenticator token-creator]}]
+  (client-authenticated-request
+   req
+   client-authenticator
+   (fn [req client] (respond-with-new-token token-creator client client))))
 
-(defmethod token-request-handler "authorization_code" 
-  [req { :keys [ client-authenticator token-creator auth-code-lookup auth-code-revoker ]}]
-  (client-authenticated-request 
-    req 
-    client-authenticator
-    (fn [req client] 
-      (if-let [code (auth-code-lookup ((req :params) :code))]
-        (if (and  (= (:client-id client) (:client-id (:client code)))
-                  (= (:redirect-uri code) ((req :params) :redirect_uri)))
-          (let [ _ (auth-code-revoker code)                  
-                 token (token-creator client (:subject code) (:scope code) (:object code))]
-             (token-response token))
-          (error-response "invalid_grant"))
-        (error-response "invalid_grant")))))
-      
+(defmethod token-request-handler "authorization_code"
+  [req {:keys [client-authenticator token-creator
+               auth-code-lookup auth-code-revoker]}]
+  (client-authenticated-request
+   req
+   client-authenticator
+   (fn [req client]
+     (if-let [code (auth-code-lookup ((req :params) :code))]
+       (if (and  (= (:client-id client) (:client-id (:client code)))
+                 (= (:redirect-uri code) ((req :params) :redirect_uri)))
+         (let [_ (auth-code-revoker code)
+               token (token-creator
+                      client (:subject code) (:scope code) (:object code))]
+           (token-response token))
+         (error-response "invalid_grant"))
+       (error-response "invalid_grant")))))
 
-(defmethod token-request-handler "password" 
-  [req { :keys [ client-authenticator token-creator user-authenticator]} ]
-  (client-authenticated-request 
-    req 
-    client-authenticator
-    (fn [req client] (if-let [user (user-authenticator ((req :params) :username) ((req :params) :password))]
-                        (respond-with-new-token token-creator client user)
-                        (error-response "invalid_grant")))))
+(defmethod token-request-handler "password"
+  [req {:keys [client-authenticator token-creator user-authenticator]}]
+  (client-authenticated-request
+   req
+   client-authenticator
+   (fn [req client] (if-let [user (user-authenticator
+                                   ((req :params) :username)
+                                   ((req :params) :password))]
+                      (respond-with-new-token token-creator client user)
+                      (error-response "invalid_grant")))))
 
 (defmethod token-request-handler :default [req _]
   (error-response "unsupported_grant_type"))
@@ -116,89 +120,103 @@
 (defn token-handler
   "Ring handler that issues oauth tokens.
 
-  Configure it by passing an optional map containing:
+   Configure it by passing an optional map containing:
 
-  :client-authenticator a function that returns a client record when passwed a correct client_id and client secret combo
-  :user-authenticator a function that returns a user when passwed a correct username and password combo
-  :auth-code-lookup  a function which returns a auth code record when passed it's code string
-  :token-creator a function that creates a new token when passed a client and a user
-  :auth-code-revoker a function that revokes a auth-code when passed an auth-code record"
+   :client-authenticator a function that returns a client record when passed a
+    correct client_id and client secret combo
+   :user-authenticator a function that returns a user when passwed a correct
+    username and password combo
+   :auth-code-lookup  a function which returns a auth code record when passed
+    it's code string
+   :token-creator a function that creates a new token when passed a client and
+    a user
+   :auth-code-revoker a function that revokes a auth-code when passed an
+    auth-code record"
   ([]
-    (token-handler {}))
+     (token-handler {}))
   ([client-authenticator user-authenticator]
-    (token-handler {:client-authenticator client-authenticator :user-authenticator user-authenticator}))
+     (token-handler {:client-authenticator client-authenticator
+                     :user-authenticator user-authenticator}))
   ([config]
-    (fn [req]
-      (token-request-handler req (merge { :client-authenticator clauth.client/authenticate-client 
-                                          :user-authenticator clauth.user/authenticate-user
-                                          :token-creator create-token
-                                          :auth-code-revoker revoke-auth-code! 
-                                          :auth-code-lookup fetch-auth-code } config)))))
- 
+     (fn [req]
+       (token-request-handler
+        req
+        (merge {:client-authenticator clauth.client/authenticate-client
+                :user-authenticator clauth.user/authenticate-user
+                :token-creator create-token
+                :auth-code-revoker revoke-auth-code!
+                :auth-code-lookup fetch-auth-code} config)))))
+
 (defn login-handler
-  "Present a login form to user and log them in by adding an access token to the session.
+  "Present a login form to user and log them in by adding an access token to
+   the session.
 
-  Configure it by passing the following to a map:
+   Configure it by passing the following to a map:
 
-  Required value
-  :client the site's own client application record
+   Required value
+   :client the site's own client application record
 
-  Optional entries to customize functionality:
-  :login-form a ring handler to display a login form
-  :user-authenticator a function that returns a user when passwed a correct username and password combo
-  :token-creator a function that creates a new token when passed a client and a user"
+   Optional entries to customize functionality:
+   :login-form a ring handler to display a login form
+   :user-authenticator a function that returns a user when passwed a correct
+    username and password combo
+   :token-creator a function that creates a new token when passed a client and
+    a user"
   [config]
-    (let [config (merge { :login-form login-form-handler
-                          :user-authenticator clauth.user/authenticate-user
-                          :token-creator clauth.token/create-token } config)
-          {:keys [client login-form user-authenticator token-creator]} config ]
-      (csrf-protect!
-        (fn [{:keys [request-method params session] :as req} ]
-          (if (= :get request-method)
-            (login-form req)
-            (if-let [user (user-authenticator (params :username) (params :password))]
-              (let 
-                [ destination (session :return-to "/")
-                  session ( dissoc (assoc session :access_token (:token (token-creator client user))) :return-to )]
-                { :status 302
-                  :headers {"Content-Type" "text/html" "Location" destination}
-                  :session session
-                  :body "Redirecting to /"})
-              (login-form req)))))))
+  (let [config (merge {:login-form login-form-handler
+                       :user-authenticator clauth.user/authenticate-user
+                       :token-creator clauth.token/create-token} config)
+        {:keys [client login-form user-authenticator token-creator]} config]
+    (csrf-protect!
+     (fn [{:keys [request-method params session] :as req}]
+       (if (= :get request-method)
+         (login-form req)
+         (if-let [user (user-authenticator (params :username)
+                                           (params :password))]
+           (let
+               [destination (session :return-to "/")
+                session (dissoc (assoc session :access_token
+                                       (:token (token-creator client user)))
+                                :return-to)]
+             {:status 302
+              :headers {"Content-Type" "text/html" "Location" destination}
+              :session session
+              :body "Redirecting to /"})
+           (login-form req)))))))
 
 (defn logout-handler
   "logout user"
   [req]
-    (assoc (redirect "/") :session ( dissoc (req :session) :access_token)))
+  (assoc (redirect "/") :session (dissoc (req :session) :access_token)))
 
 (defn logged-in?
   "returns true if request is logged in"
   [req]
   (not (nil? (req :access-token))))
-  
+
 (defn current-user
   "returns current user associated with request"
   [req]
   (if (logged-in? req)
     (:subject (req :access-token))))
-  
+
 (defn authorization-response
   "Create a proper redirection response depending on response_type"
-  [req response_params ]
-  (let [ params (req :params)
-         redirect_uri (params :redirect_uri)]
-    (redirect (str redirect_uri 
-        (if (= (params :response_type) "token")
-          "#"
-          "?")
-        (url-encode (merge response_params (filter val (select-keys (req :params) [:state]))))
-      ))))
+  [req response_params]
+  (let [params (req :params)
+        redirect_uri (params :redirect_uri)]
+    (redirect (str redirect_uri
+                   (if (= (params :response_type) "token") "#" "?")
+                   (url-encode (merge response_params
+                                      (filter val
+                                              (select-keys (req :params)
+                                                           [:state]))))))))
 
 (defn authorization-error-response
   "redirect to client with error code"
   [req error]
   (if ((req :params) :redirect_uri)
-    (authorization-response req { "error" error })
+    (authorization-response req {"error" error})
     (error-page error)))
 
 (defn response-type
@@ -207,53 +225,57 @@
 
 (defmulti authorization-request-handler response-type)
 
-(defmethod authorization-request-handler "token" [req {:keys [client-lookup token-lookup token-creator ]}]
-  (let [ params (req :params)
-         client (client-lookup (params :client_id))
-         user ( :subject (token-lookup (:access_token (req :session))))
-         token (token-creator client user)]
-    (authorization-response req {:access_token (:token token) :token_type "bearer"})))
+(defmethod authorization-request-handler "token"
+  [req {:keys [client-lookup token-lookup token-creator]}]
+  (let [params (req :params)
+        client (client-lookup (params :client_id))
+        user (:subject (token-lookup (:access_token (req :session))))
+        token (token-creator client user)]
+    (authorization-response req {:access_token (:token token)
+                                 :token_type "bearer"})))
 
-(defmethod authorization-request-handler "code" [req {:keys [client-lookup token-lookup auth-code-creator ]}]
-  (let [ params (req :params)
-         client (client-lookup (params :client_id))
-         user ( :subject (token-lookup (:access_token (req :session))))
-         code (auth-code-creator client user (:redirect_uri params))]
+(defmethod authorization-request-handler "code"
+  [req {:keys [client-lookup token-lookup auth-code-creator]}]
+  (let [params (req :params)
+        client (client-lookup (params :client_id))
+        user (:subject (token-lookup (:access_token (req :session))))
+        code (auth-code-creator client user (:redirect_uri params))]
     (authorization-response req {:code (:code code)})))
 
 (defmethod authorization-request-handler :default [req]
   (authorization-error-response req "unsupported_grant_type"))
 
 (defn authorization-handler
-  "present a login form to user and log them in by adding an access token to the session
+  "present a login form to user and log them in by adding an access token to
+   the session
 
-  Configure it by passing an optional map containing:
+   Configure it by passing an optional map containing:
 
-  :authorization-form a ring handler to display a authorization form
-  :client-lookup a function which returns a client when passed its client_id
-  :token-lookup  a function which returns a token record when passed it's token string
-  :token-creator a function that creates a new token when passed a client and a user
-  :auth-code-creator a function that creates an authorization code record when passed a client, user and redirect uri"
+   :authorization-form a ring handler to display a authorization form
+   :client-lookup a function which returns a client when passed its client_id
+   :token-lookup  a function which returns a token record when passed it's
+    token string
+   :token-creator a function that creates a new token when passed a client and
+    a user
+   :auth-code-creator a function that creates an authorization code record when
+    passed a client, user and redirect uri"
   ([]
-    (authorization-handler {}))
+     (authorization-handler {}))
   ([config]
-    (let [config (merge {:authorization-form authorization-form-handler
-                        :client-lookup clauth.client/fetch-client
-                        :token-lookup clauth.token/fetch-token
-                        :token-creator clauth.token/create-token 
-                        :auth-code-creator clauth.auth-code/create-auth-code} config)
-          authorization-form (config :authorization-form)]
-
-      (require-user-session!
+     (let [config (merge {:authorization-form authorization-form-handler
+                          :client-lookup clauth.client/fetch-client
+                          :token-lookup clauth.token/fetch-token
+                          :token-creator clauth.token/create-token
+                          :auth-code-creator clauth.auth-code/create-auth-code}
+                         config)
+           authorization-form (config :authorization-form)]
+       (require-user-session!
         (csrf-protect!
-          (fn [ {:keys [params] :as req}]
-            (if (and (params :response_type) (params :client_id))
-              (if (some (partial = (params :response_type)) ["code" "token"] )
-                (if (= :get (req :request-method))
-                  (authorization-form req)
-                  (authorization-request-handler req config)
-                )
-                (authorization-error-response req "unsupported_response_type")
-              )
-              (authorization-error-response req "invalid_request"))))))))
-
+         (fn [{:keys [params] :as req}]
+           (if (and (params :response_type) (params :client_id))
+             (if (some (partial = (params :response_type)) ["code" "token"])
+               (if (= :get (req :request-method))
+                 (authorization-form req)
+                 (authorization-request-handler req config))
+               (authorization-error-response req "unsupported_response_type"))
+             (authorization-error-response req "invalid_request"))))))))

--- a/src/clauth/middleware.clj
+++ b/src/clauth/middleware.clj
@@ -1,6 +1,5 @@
 (ns clauth.middleware
-  (:use [clauth.token]
-        [ring.util.response :only [redirect]]))
+  (:require [ring.util.response :refer [redirect]]))
 
 (defn wrap-bearer-token
   "Wrap request with a OAuth2 bearer token as defined in

--- a/src/clauth/middleware.clj
+++ b/src/clauth/middleware.clj
@@ -3,56 +3,54 @@
         [ring.util.response :only [redirect]]))
 
 (defn wrap-bearer-token
-  "Wrap request with a OAuth2 bearer token as defined in http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08.
+  "Wrap request with a OAuth2 bearer token as defined in
+   http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08.
 
-  A find-token function is passed the token and returns a clojure map describing the subject of the token.
+   A find-token function is passed the token and returns a clojure map
+   describing the subject of the token.
 
-  It supports the following ways of setting the token.
+   It supports the following ways of setting the token.
 
-  * [Authorization header](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.1)
-  * [Form encoded body parameter](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.2)
-  * [URI query field](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.3)
-  * Non standard http cookie ('access_token') for use in interactive applications
+   * [Authorization header](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.1)
+   * [Form encoded body parameter](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.2)
+   * [URI query field](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.3)
+   * Non standard http cookie ('access_token') for use in interactive applications
 
-
-  The subject is added to the :access-token key of the request."
-  
+   The subject is added to the :access-token key of the request."
   ([app]
-    (wrap-bearer-token app clauth.token/find-valid-token ))
+     (wrap-bearer-token app clauth.token/find-valid-token))
   ([app find-token]
-    (fn [req]
-      (let [auth ((:headers req {}) "authorization")
-            token (or (last
-                    (re-find #"^Bearer (.*)$" (str auth)))
-                    ((:params req {}) :access_token)
-                    ((:params req {}) "access_token")
-                    ((:session req {}) :access_token)
-                    (((:cookies req {}) "access_token" {}) :value )
-                  )]
-        (if-let [access-token (and token (find-token token))]
-          (app ( assoc req :access-token access-token))
-          (app req))))))
+     (fn [req]
+       (let [auth ((:headers req {}) "authorization")
+             token (or (last
+                        (re-find #"^Bearer (.*)$" (str auth)))
+                       ((:params req {}) :access_token)
+                       ((:params req {}) "access_token")
+                       ((:session req {}) :access_token)
+                       (((:cookies req {}) "access_token" {}) :value))]
+         (if-let [access-token (and token (find-token token))]
+           (app (assoc req :access-token access-token))
+           (app req))))))
 
 (defn wrap-user-session
-  "Wrap request with a OAuth2 token stored in the session. Use this for optional authentication where no API access is wished.
+  "Wrap request with a OAuth2 token stored in the session. Use this for
+   optional authentication where no API access is wished.
 
-  A find-token function is passed the token and returns a clojure map describing the subject of the token.
+   A find-token function is passed the token and returns a clojure map
+   describing the subject of the token.
 
-  It supports the following ways of setting the token.
+   It supports the following ways of setting the token.
 
-
-  The subject is added to the :access-token key of the request."
-  
+   The subject is added to the :access-token key of the request."
   ([app]
-    (wrap-user-session app clauth.token/find-valid-token ))
+     (wrap-user-session app clauth.token/find-valid-token))
   ([app find-token]
-    (fn [req]
-      (let [auth ((:headers req {}) "authorization")
-            token ((:session req {}) :access_token)]
-        (if-let [access-token (find-token token)]
-          (app ( assoc req :access-token access-token))
-          (app req))))))
-
+     (fn [req]
+       (let [auth ((:headers req {}) "authorization")
+             token ((:session req {}) :access_token)]
+         (if-let [access-token (find-token token)]
+           (app (assoc req :access-token access-token))
+           (app req))))))
 
 (defn is-html?
   "returns true if request has text/html in the accept header"
@@ -63,9 +61,13 @@
 (defn is-form?
   "returns true if request has form in the accept header"
   [req]
-  (if (or (not (:access-token req)) (and (:access-token req) (:access_token (req :session {}))))
+  (if (or (not (:access-token req)) (and (:access-token req)
+                                         (:access_token (req :session {}))))
     (if-let [content-type (req :content-type)]
-      (if (seq (filter (partial  = content-type) ["application/x-www-form-urlencoded" "multipart/form-data"])) true))))
+      (if (seq (filter
+                (partial  = content-type)
+                ["application/x-www-form-urlencoded" "multipart/form-data"]))
+        true))))
 
 (defmacro if-html
   "if request is for a html page it runs the first handler if not the second"
@@ -76,7 +78,6 @@
   "if request is url form encoded it runs the first handler if not the second"
   [req html api]
   `(if (is-form? ~req) ~html ~api))
-
 
 (defn csrf-token
   "extract csrf token from request"
@@ -95,92 +96,91 @@
 (defn csrf-protect!
   "add a csrf token to session and reject a post request without it"
   [app]
-    (fn
-      [{:keys [request-method session params] :as req }]
-      (if (and (= request-method :get)
-               (is-html? req))
-        (let [req (with-csrf-token req)]
-          (if-let [token (:csrf-token req)]
-            (assoc-in (app req) [:session :csrf-token] token)
-            (app req)))
+  (fn
+    [{:keys [request-method session params] :as req}]
+    (if (and (= request-method :get)
+             (is-html? req))
+      (let [req (with-csrf-token req)]
+        (if-let [token (:csrf-token req)]
+          (assoc-in (app req) [:session :csrf-token] token)
+          (app req)))
+      (if-form req
+               (let [token (csrf-token req)]
+                 (if (and token (params :csrf-token)
+                          (= token (params :csrf-token)))
+                   (app req)
+                   {:status 403 :body "csrf token does not match"}))
+               (app req)))))
 
-          (if-form req
-            (let [token (csrf-token req)]
-              (if (and token (params :csrf-token) (= token (params :csrf-token)))
-                (app req)
-                { :status 403 :body "csrf token does not match"}))
-            (app req)))))
-
-
-(defn authentication-required-response 
+(defn authentication-required-response
   "Return HTTP 401 Response"
-  [ req ]
-  (if-html req 
-    (assoc (redirect "/login") :session {:return-to (str (req :uri) "?" (req :query-string))})
-    { :status  401
-    :headers {
-      "Content-Type" "text/plain"
-      "WWW-Authenticate" "Bearer realm=\"OAuth required\""}
-    :body "access denied" }))
-
+  [req]
+  (if-html req (assoc (redirect "/login") :session
+                      {:return-to (str (req :uri) "?" (req :query-string))})
+           {:status 401
+            :headers {"Content-Type" "text/plain"
+                      "WWW-Authenticate" "Bearer realm=\"OAuth required\""}
+            :body "access denied"}))
 
 (defn require-bearer-token!
-  "Require request with a OAuth2 bearer token as defined in http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08.
+  "Require request with a OAuth2 bearer token as defined in
+   http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08.
 
-  A find-token function is passed the token and returns a clojure map describing the token.
+   A find-token function is passed the token and returns a clojure map
+   describing the token.
 
-  It supports the following ways of setting the token.
+   It supports the following ways of setting the token.
 
-  * [Authorization header](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.1)
-  * [Form encoded body parameter](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.2)
-  * [URI query field](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.3)
-  * Non standard http cookie ('access_token') for use in interactive applications
+   * [Authorization header](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.1)
+   * [Form encoded body parameter](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.2)
+   * [URI query field](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.3)
+   * Non standard http cookie ('access_token') for use in interactive applications
 
 
-  The token is added to the :access-token key of the request.
+   The token is added to the :access-token key of the request.
 
-  will return a [HTTP 401 header](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.4) if no valid token is present."
-
+   will return a [HTTP 401 header](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.4) if no valid token is present."
   ([app]
-    (require-bearer-token! app clauth.token/find-valid-token ))  
+     (require-bearer-token! app clauth.token/find-valid-token))
   ([app find-token]
-    (wrap-bearer-token 
-     (fn [req]
-       (if (req :access-token)
-           (app req)
-           (authentication-required-response req ))) find-token)))
+     (wrap-bearer-token
+      (fn [req]
+        (if (req :access-token)
+          (app req)
+          (authentication-required-response req))) find-token)))
 
 (defn request-uri [req]
   (if (req :query-string)
     (str (req :uri) "?" (req :query-string))
     (req :uri)))
 
-(defn user-session-required-response 
+(defn user-session-required-response
   "Return HTTP 403 Response or redirects to login"
-  [ req ]
-  (if-html req 
-    (assoc (redirect "/login") :session {:return-to (request-uri req)})
-    { :status  403
-      :headers {
-        "Content-Type" "text/plain" }
-      :body "Forbidden" }))
+  [req]
+  (if-html req
+           (assoc (redirect "/login") :session {:return-to (request-uri req)})
+           {:status 403
+            :headers {"Content-Type" "text/plain"}
+            :body "Forbidden"}))
 
 (defn require-user-session!
   "Require that user is authenticated via an access_token stored in the session.
 
-  Use this to protect parts of your application that web services should not have access to.
+   Use this to protect parts of your application that web services should not
+   have access to.
 
-  A find-token function is passed the token and returns a clojure map describing the token.
+   A find-token function is passed the token and returns a clojure map
+   describing the token.
 
-  The token is added to the :access-token key of the request.
+   The token is added to the :access-token key of the request.
 
-  Will redirect user to login url if not authenticated and issue a 403 to other requests."
-
+   Will redirect user to login url if not authenticated and issue a 403 to
+   other requests."
   ([app]
-    (require-user-session! app clauth.token/find-valid-token ))  
+     (require-user-session! app clauth.token/find-valid-token))
   ([app find-token]
-    (wrap-user-session
-     (fn [req]
-       (if (req :access-token)
-           (app req)
-           (user-session-required-response req ))) find-token)))
+     (wrap-user-session
+      (fn [req]
+        (if (req :access-token)
+          (app req)
+          (user-session-required-response req))) find-token)))

--- a/src/clauth/middleware.clj
+++ b/src/clauth/middleware.clj
@@ -1,5 +1,6 @@
 (ns clauth.middleware
-  (:require [ring.util.response :refer [redirect]]))
+  (:require [ring.util.response :refer [redirect]]
+            [clauth.token :as token]))
 
 (defn wrap-bearer-token
   "Wrap request with a OAuth2 bearer token as defined in
@@ -17,7 +18,7 @@
 
    The subject is added to the :access-token key of the request."
   ([app]
-     (wrap-bearer-token app clauth.token/find-valid-token))
+     (wrap-bearer-token app token/find-valid-token))
   ([app find-token]
      (fn [req]
        (let [auth ((:headers req {}) "authorization")
@@ -42,7 +43,7 @@
 
    The subject is added to the :access-token key of the request."
   ([app]
-     (wrap-user-session app clauth.token/find-valid-token))
+     (wrap-user-session app token/find-valid-token))
   ([app find-token]
      (fn [req]
        (let [auth ((:headers req {}) "authorization")
@@ -140,7 +141,7 @@
 
    will return a [HTTP 401 header](http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-08#section-2.4) if no valid token is present."
   ([app]
-     (require-bearer-token! app clauth.token/find-valid-token))
+     (require-bearer-token! app token/find-valid-token))
   ([app find-token]
      (wrap-bearer-token
       (fn [req]
@@ -176,7 +177,7 @@
    Will redirect user to login url if not authenticated and issue a 403 to
    other requests."
   ([app]
-     (require-user-session! app clauth.token/find-valid-token))
+     (require-user-session! app token/find-valid-token))
   ([app find-token]
      (wrap-user-session
       (fn [req]

--- a/src/clauth/store.clj
+++ b/src/clauth/store.clj
@@ -2,27 +2,31 @@
 
 (defprotocol Store
   "Store objects"
-  (fetch [ e k ] "Find the item based on a key.")
-  (revoke! [ e k ] "Invalidate or remove the item based on a key")
-  (store! [ e key_param item ] "Store the given map using the value of the keyword key_param and return it.")
-  (entries [e] "sequence of entries")
-  (reset-store! [e] "clear all entries"))
+  (fetch [e k]
+    "Find the item based on a key.")
+  (revoke! [e k]
+    "Invalidate or remove the item based on a key")
+  (store! [e key_param item]
+    "Store the given map using the value of the kw key_param and return it.")
+  (entries [e]
+    "sequence of entries")
+  (reset-store! [e]
+    "clear all entries"))
 
-(defrecord MemoryStore [data] 
-  Store 
+(defrecord MemoryStore [data]
+  Store
   (fetch [this t] (@data t))
   (revoke! [this t] (swap! data dissoc t))
   (store! [this key_param item]
     (do
       (swap! data assoc (key_param item) item)
-      item)
-    )
+      item))
   (entries [this] (or (vals @data) []))
   (reset-store! [this] (reset! data {})))
 
-(defn create-memory-store 
+(defn create-memory-store
   "Create a memory token store"
   ([] (create-memory-store {}))
   ([data]
-    (MemoryStore. (atom data))))
+     (MemoryStore. (atom data))))
 

--- a/src/clauth/store/redis.clj
+++ b/src/clauth/store/redis.clj
@@ -1,7 +1,6 @@
 (ns clauth.store.redis
-  (:use [clauth.store])
-  (:require [redis.core :as redis]
-            [cheshire.core]))
+  (:require [clauth.store :refer [Store]]
+            [redis.core :as redis]))
 
 (defn namespaced-keys
   "get namespaced list of keys"

--- a/src/clauth/store/redis.clj
+++ b/src/clauth/store/redis.clj
@@ -3,59 +3,55 @@
   (:require [redis.core :as redis]
             [cheshire.core]))
 
-
-(defn namespaced-keys 
+(defn namespaced-keys
   "get namespaced list of keys"
-  [namespace] 
+  [namespace]
   (redis/keys (str namespace "/*")))
 
 (defn all-in-namespace
   "get all items in namespace"
   [namespace]
   (let [ks (remove nil? (namespaced-keys namespace))]
-    (if (not-empty ks) (apply redis/mget ks)))) 
-    
+    (if (not-empty ks) (apply redis/mget ks))))
 
-(defrecord RedisStore [namespace] 
-  Store 
+(defrecord RedisStore [namespace]
+  Store
   (fetch [this t] (if-let [j (redis/get (str namespace "/" t))]
-                          (cheshire.core/parse-string j true)))
-  (revoke! [this t] (redis/del (str namespace "/" t)))       
+                    (cheshire.core/parse-string j true)))
+  (revoke! [this t] (redis/del (str namespace "/" t)))
   (store! [this key_param item]
     (do
-      (redis/set (str namespace "/" (key_param item)) (cheshire.core/generate-string item))
-      item)
-    )
-  (entries [this] (map #( cheshire.core/parse-string % true) (all-in-namespace namespace) ))
+      (redis/set (str namespace "/" (key_param item))
+                 (cheshire.core/generate-string item))
+      item))
+  (entries [this] (map #( cheshire.core/parse-string % true)
+                       (all-in-namespace namespace) ))
   (reset-store! [this] (redis/flushdb)))
 
-(defn create-redis-store 
+(defn create-redis-store
   "Create a redis store"
-  ([namespace]
-    (RedisStore. namespace)))
+  [namespace]
+  (RedisStore. namespace))
 
-(def redis-server    
-  (if-let [ redis_url ( or (get (System/getenv) "REDIS_URL") (get (System/getenv) "REDISTOGO_URL"))]
-    (let [ uri (new java.net.URI redis_url)
-           host (.getHost uri)
-           port (.getPort uri)
-           password ( last (clojure.string/split (.getUserInfo uri) #":"))]
-      { :host host
-        :port port
-        :password password })
-    {
-      :host "127.0.0.1"
-      :port 6379
-      :db 14 }))
+(def redis-server
+  (if-let [redis_url (or (get (System/getenv) "REDIS_URL")
+                         (get (System/getenv) "REDISTOGO_URL"))]
+    (let [uri (new java.net.URI redis_url)
+          host (.getHost uri)
+          port (.getPort uri)
+          password (last (clojure.string/split (.getUserInfo uri) #":"))]
+      {:host host
+       :port port
+       :password password})
+    {:host "127.0.0.1"
+     :port 6379
+     :db 14}))
 
 (defmacro with-redis
-  "Evaluates body in the context of a new connection to either local Redis server or server specified in REDIS_URL or REDISTOGO_URL"
-  
-  [ & body]
+  "Evaluates body in the context of a new connection to either local Redis
+   server or server specified in REDIS_URL or REDISTOGO_URL"
+  [& body]
   `(redis/with-server redis-server ~@body))
 
-
 (defn wrap-redis [app]
-  (fn [req]
-      (with-redis
-        (app req))))
+  (fn [req] (with-redis (app req))))

--- a/src/clauth/store/redis.clj
+++ b/src/clauth/store/redis.clj
@@ -23,8 +23,8 @@
       (redis/set (str namespace "/" (key_param item))
                  (cheshire.core/generate-string item))
       item))
-  (entries [this] (map #( cheshire.core/parse-string % true)
-                       (all-in-namespace namespace) ))
+  (entries [this] (map #(cheshire.core/parse-string % true)
+                       (all-in-namespace namespace)))
   (reset-store! [this] (redis/flushdb)))
 
 (defn create-redis-store

--- a/src/clauth/token.clj
+++ b/src/clauth/token.clj
@@ -1,28 +1,25 @@
 (ns clauth.token
-    (:use [clauth.store])
-    (:require [crypto.random]
-              [clj-time.core :as time]
-              [clj-time.coerce]
-              [cheshire.core]))
+  (:use [clauth.store])
+  (:require [crypto.random]
+            [clj-time.core :as time]
+            [clj-time.coerce]
+            [cheshire.core]))
 
 (defprotocol Expirable
   "Check if object is valid"
-  (is-valid? [ t ] "is the object still valid"))
+  (is-valid? [t] "is the object still valid"))
 
-(extend-protocol Expirable clojure.lang.IPersistentMap 
+(extend-protocol Expirable clojure.lang.IPersistentMap
   (is-valid? [t] (if-let [expiry (:expires t)]
-                          (time/after? (clj-time.coerce/to-date-time expiry) (time/now) )
-                          true)))
+                   (time/after? (clj-time.coerce/to-date-time expiry)
+                                (time/now))
+                   true)))
 
-(extend-protocol Expirable nil 
-  (is-valid? [t] false))
+(extend-protocol Expirable nil (is-valid? [t] false))
 
-(defrecord OAuthToken
-  [token client subject expires scope object])
+(defrecord OAuthToken [token client subject expires scope object])
 
-(defn generate-token 
-  "generate a unique token"
-  [] (crypto.random/base32 20))
+(defn generate-token "generate a unique token" [] (crypto.random/base32 20))
 
 (defn oauth-token
   "The oauth-token defines supports various functions to verify the validity
@@ -37,21 +34,20 @@
   * object  - An optional object authorized. Eg. account, photo"
 
   ([attrs] ; Swiss army constructor. There must be a better way.
-    (cond
+     (cond
       (nil? attrs) nil
       (instance? OAuthToken attrs) attrs
-      (instance? java.lang.String attrs) (oauth-token (cheshire.core/parse-string attrs true))
-      :default (OAuthToken. (attrs :token) (attrs :client) (attrs :subject) (attrs :expires) (attrs :scope) (attrs :object))))
+      (instance? java.lang.String attrs) (oauth-token
+                                          (cheshire.core/parse-string
+                                           attrs true))
+      :default (OAuthToken. (attrs :token) (attrs :client) (attrs :subject)
+                            (attrs :expires) (attrs :scope) (attrs :object))))
   ([client subject]
-    (oauth-token client subject nil nil nil)
-    )
+     (oauth-token client subject nil nil nil))
   ([client subject expires scope object]
-    (oauth-token (generate-token) client subject expires scope object)
-    )
+     (oauth-token (generate-token) client subject expires scope object))
   ([token client subject expires scope object]
-    (OAuthToken. token client subject expires scope object)
-    )
-  )
+     (OAuthToken. token client subject expires scope object)))
 
 (defonce token-store (atom (create-memory-store)))
 
@@ -75,20 +71,19 @@
   []
   (map oauth-token (entries @token-store)))
 
-(defn create-token 
+(defn create-token
   "create a unique token and store it in the token store"
   ([client subject]
-    (create-token (oauth-token client subject)))
+     (create-token (oauth-token client subject)))
   ([client subject scope object]
-    (create-token client subject nil scope object))
+     (create-token client subject nil scope object))
   ([client subject expires scope object]
-    (create-token (oauth-token client subject expires scope object)))
-  ([ token ]
-    (store-token token)
-    ))
-  
+     (create-token (oauth-token client subject expires scope object)))
+  ([token]
+     (store-token token)))
+
 (defn find-valid-token
   "return a token from the store if it is valid."
   [t]
   (if-let [token (fetch-token t)]
-    (if (is-valid? token) token )))
+    (if (is-valid? token) token)))

--- a/src/clauth/token.clj
+++ b/src/clauth/token.clj
@@ -1,8 +1,9 @@
 (ns clauth.token
   (:require [clauth.store :as store]
             [crypto.random :as random]
-            [clj-time.core :as time]
-            [clj-time.coerce :as coerce]
+            [clj-time
+             [core :as time]
+             [coerce :as coerce]]
             [cheshire.core :as cheshire]))
 
 (defprotocol Expirable

--- a/src/clauth/user.clj
+++ b/src/clauth/user.clj
@@ -1,9 +1,9 @@
 (ns clauth.user
-  (:use [clauth.store])
-  (:require [cheshire.core])
+  (:require [clauth.store :as store]
+            [cheshire.core :as cheshire])
   (:import [org.mindrot.jbcrypt BCrypt]))
 
-(defonce user-store (atom (create-memory-store)))
+(defonce user-store (atom (store/create-memory-store)))
 
 (defrecord User [login password name url])
 
@@ -24,7 +24,7 @@
       (nil? attrs) nil
       (instance? User attrs) attrs
       (instance? java.lang.String attrs) (new-user
-                                          (cheshire.core/parse-string
+                                          (cheshire/parse-string
                                            attrs true))
       :default (User. (attrs :login) (attrs :password) (attrs :name)
                       (attrs :url))))
@@ -34,22 +34,22 @@
 (defn reset-user-store!
   "mainly for used in testing. Clears out all users."
   []
-  (reset-store! @user-store))
+  (store/reset-store! @user-store))
 
 (defn fetch-user
   "Find user based on login"
   [t]
-  (new-user (fetch @user-store t)))
+  (new-user (store/fetch @user-store t)))
 
 (defn store-user
   "Store the given User and return it."
   [t]
-  (store! @user-store :login t))
+  (store/store! @user-store :login t))
 
 (defn users
   "Sequence of users"
   []
-  (entries @user-store))
+  (store/entries @user-store))
 
 (defn register-user
   "create a unique user and store it in the user store"

--- a/src/clauth/user.clj
+++ b/src/clauth/user.clj
@@ -1,36 +1,36 @@
 (ns clauth.user
-    (:use [clauth.store])
-    (:require [cheshire.core])
-    (:import [org.mindrot.jbcrypt BCrypt]))
-
+  (:use [clauth.store])
+  (:require [cheshire.core])
+  (:import [org.mindrot.jbcrypt BCrypt]))
 
 (defonce user-store (atom (create-memory-store)))
 
-(defrecord User
-  [login password name url])
+(defrecord User [login password name url])
 
-(defn bcrypt 
+(defn bcrypt
   "Perform BCrypt hash of password"
-  [password] 
+  [password]
   (BCrypt/hashpw password (BCrypt/gensalt)))
 
-(defn valid-password? 
+(defn valid-password?
   "Verify that candidate password matches the hashed bcrypted password"
-  [candidate hashed] 
+  [candidate hashed]
   (BCrypt/checkpw candidate hashed))
 
 (defn new-user
   "Create new user record"
   ([attrs] ; Swiss army constructor. There must be a better way.
-    (cond
+     (cond
       (nil? attrs) nil
       (instance? User attrs) attrs
-      (instance? java.lang.String attrs) (new-user (cheshire.core/parse-string attrs true))
-      :default (User. (attrs :login) (attrs :password) (attrs :name) (attrs :url))))
+      (instance? java.lang.String attrs) (new-user
+                                          (cheshire.core/parse-string
+                                           attrs true))
+      :default (User. (attrs :login) (attrs :password) (attrs :name)
+                      (attrs :url))))
+  ([login password] (new-user login password nil nil))
+  ([login password name url] (User. login (bcrypt password) name url)))
 
-  ([ login password ] (new-user login password nil nil))
-  ([ login password name url ] (User. login (bcrypt password) name url)))
-  
 (defn reset-user-store!
   "mainly for used in testing. Clears out all users."
   []
@@ -51,17 +51,16 @@
   []
   (entries @user-store))
 
-(defn register-user 
+(defn register-user
   "create a unique user and store it in the user store"
-  ([ login password ] (register-user login password nil nil))
-  ([ login password name url ]
-    (let [user (new-user login password name url)]
-      (store-user user))))
+  ([login password] (register-user login password nil nil))
+  ([login password name url]
+     (let [user (new-user login password name url)]
+       (store-user user))))
 
 (defn authenticate-user
   "authenticate user application using login and password"
   [login password]
-  (if-let [ user (fetch-user login)]
+  (if-let [user (fetch-user login)]
     (if (valid-password? password (:password user))
-      user
-    )))
+      user)))

--- a/src/clauth/views.clj
+++ b/src/clauth/views.clj
@@ -5,67 +5,67 @@
         [hiccup.form]
         [clauth.client :only [fetch-client]]))
 
-(defn csrf-field 
+(defn csrf-field
   "hidden form field containing csrf-token"
   [req]
   (hidden-field :csrf-token (csrf-token req)))
 
 (defn include-hidden-params
   "Include certain parameters as hidden fields if present"
-  [{ params :params} fields]
-    (map #(hidden-field (key %) (val %)) 
-    (filter val (select-keys params fields))))
+  [{params :params} fields]
+  (map #(hidden-field (key %) (val %))
+       (filter val (select-keys params fields))))
 
-(defn login-form 
-  ([req] (login-form req (req :uri) ((req :params) :username) ((req :params) :password)))
+(defn login-form
+  ([req] (login-form req (req :uri)
+                     ((req :params) :username)
+                     ((req :params) :password)))
   ([req uri username password]
-    (html
+     (html
       (form-to [:post (req :uri)]
-        (csrf-field req)
-        (label :username "User name:")
-        (text-field :username username)
-        (label :password "Password:")
-        (password-field :password password)
-        [:div {:class "form-actions"}
-          [:button {:type "submit" :class "btn btn-primary"} "Login"]]))))
+               (csrf-field req)
+               (label :username "User name:")
+               (text-field :username username)
+               (label :password "Password:")
+               (password-field :password password)
+               [:div {:class "form-actions"}
+                [:button {:type "submit" :class "btn btn-primary"} "Login"]]))))
 
 (defn login-form-handler
   "Login form ring handler"
   [req]
-  {
-    :status 200
-    :headers {"Content-Type" "text/html"}
-    :body (login-form req)})
+  {:status 200
+   :headers {"Content-Type" "text/html"}
+   :body (login-form req)})
 
-(defn authorization-form 
+(defn authorization-form
   ([req]
-    (let [client (fetch-client ((req :params) :client_id))]
-      (html
+     (let [client (fetch-client ((req :params) :client_id))]
+       (html
         (form-to [:post (req :uri)]
-          (csrf-field req)
-          (include-hidden-params req [:client_id :response_type :redirect_uri :scope :state])
-          [:h2 (:name client) " requested authorization"]
-          [:div {:class "form-actions"}
-            [:button {:type "submit" :class "btn btn-primary"} "Authorize"]
-            [:a {:class "btn" :href (or ((req :params) "redirect_uri") "/")} "Cancel"]])))))
+                 (csrf-field req)
+                 (include-hidden-params req [:client_id :response_type
+                                             :redirect_uri :scope :state])
+                 [:h2 (:name client) " requested authorization"]
+                 [:div {:class "form-actions"}
+                  [:button {:type "submit" :class "btn btn-primary"}
+                   "Authorize"]
+                  [:a {:class "btn" :href (or ((req :params) "redirect_uri")
+                                              "/")} "Cancel"]])))))
 
 (defn authorization-form-handler
   "Login form ring handler"
   [req]
-  {
-    :status 200
-    :headers {"Content-Type" "text/html"}
-    :body (authorization-form req)})
+  {:status 200
+   :headers {"Content-Type" "text/html"}
+   :body (authorization-form req)})
 
 (defn error-page
   "returns a simple error page"
   [error]
-  (response (html
-    [:h1 error])
-  ))
+  (response (html [:h1 error])))
 
 (defn hello-world
   [req]
   (let [user (:subject (req :access-token))]
-    (response (html
-              [:h1 "Hello " (:login user)]))))
+    (response (html [:h1 "Hello " (:login user)]))))

--- a/src/clauth/views.clj
+++ b/src/clauth/views.clj
@@ -1,9 +1,10 @@
 (ns clauth.views
-  (:use [ring.util.response]
-        [clauth.middleware :only [csrf-token]]
-        [hiccup.core]
-        [hiccup.form]
-        [clauth.client :only [fetch-client]]))
+  (:require [ring.util.response :refer [response]]
+            [clauth.middleware :refer [csrf-token]]
+            [hiccup.core :refer [html]]
+            [hiccup.form :refer [hidden-field form-to label text-field
+                                 password-field]]
+            [clauth.client :refer [fetch-client]]))
 
 (defn csrf-field
   "hidden form field containing csrf-token"

--- a/src/clauth/views.clj
+++ b/src/clauth/views.clj
@@ -1,9 +1,10 @@
 (ns clauth.views
   (:require [ring.util.response :refer [response]]
             [clauth.middleware :refer [csrf-token]]
-            [hiccup.core :refer [html]]
-            [hiccup.form :refer [hidden-field form-to label text-field
-                                 password-field]]
+            [hiccup
+             [core :refer [html]]
+             [form
+              :refer [hidden-field form-to label text-field password-field]]]
             [clauth.client :refer [fetch-client]]))
 
 (defn csrf-field

--- a/test/clauth/test/auth_code.clj
+++ b/test/clauth/test/auth_code.clj
@@ -1,45 +1,47 @@
 (ns clauth.test.auth-code
-  (:use [clauth.auth-code]
-        [clauth.token]
-        [clojure.test])
-  (:require [clj-time.core :as time]))
+  (:require [clojure.test :refer :all]
+            [clauth
+             [auth-code :as base]
+             [token :as token]]
+            [clj-time.core :as time]))
 
 (deftest auth-code-records
-  (let [record (oauth-code "my-client" "user" "http://test.com/redirect")]
+  (let [record (base/oauth-code "my-client" "user" "http://test.com/redirect")]
     (is (= "my-client" (:client record)) "should have client")
     (is (= "user" (:subject record)) "should have subject")
     (is (= "http://test.com/redirect" (:redirect-uri record))
         "should have redirect-uri")
     (is (not (nil? (:code record))) "should include code field")
-    (is (is-valid? record) "should be valid by default")))
+    (is (token/is-valid? record) "should be valid by default")))
 
 (deftest auth-code-creation
-  (reset-auth-code-store!)
-  (is (= 0 (count (auth-codes))) "starts out empty")
-  (let [record (create-auth-code "my-client" "my-user"
-                                 "http://test.com/redirect")]
+  (base/reset-auth-code-store!)
+  (is (= 0 (count (base/auth-codes))) "starts out empty")
+  (let [record (base/create-auth-code "my-client" "my-user"
+                                      "http://test.com/redirect")]
     (is (= "my-client" ( :client record )) "should have client")
     (is (= "my-user" ( :subject record )) "should have subject")
     (is (= "http://test.com/redirect" ( :redirect-uri record ))
         "should have redirect-uri")
     (is (not (nil? (:code record ))) "should include auth-code field")
-    (is (= 1 (count (auth-codes ))) "added one")
-    (is (= record (first (auth-codes ))) "added one")
-    (is (= record (find-valid-auth-code (:code record))))))
+    (is (= 1 (count (base/auth-codes ))) "added one")
+    (is (= record (first (base/auth-codes ))) "added one")
+    (is (= record (base/find-valid-auth-code (:code record))))))
 
 (deftest auth-code-validity
-  (is (is-valid? {}) "by default it's valid")
-  (is (not (is-valid? nil)) "nil is always false")
-  (is (is-valid? {:expires (time/plus (time/now) (time/days 1))})
+  (is (token/is-valid? {}) "by default it's valid")
+  (is (not (token/is-valid? nil)) "nil is always false")
+  (is (token/is-valid? {:expires (time/plus (time/now) (time/days 1))})
       "valid if expiry date is in the future")
-  (is (not (is-valid? {:expires (time/date-time 2012 3 13)}))
+  (is (not (token/is-valid? {:expires (time/date-time 2012 3 13)}))
       "expires if past expiry date"))
 
 (deftest auth-code-store-implementation
-  (reset-auth-code-store!)
-  (is (= 0 (count (auth-codes))) "starts out empty")
-  (let [record (oauth-code "my-client" "my-user" "http://test.com/redirect")]
-    (is (nil? (fetch-auth-code (:code record))))
-    (do (store-auth-code record)
-        (is (= record (fetch-auth-code (:code record))))
-        (is (= 1 (count (auth-codes))) "added one"))))
+  (base/reset-auth-code-store!)
+  (is (= 0 (count (base/auth-codes))) "starts out empty")
+  (let [record (base/oauth-code
+                "my-client" "my-user" "http://test.com/redirect")]
+    (is (nil? (base/fetch-auth-code (:code record))))
+    (do (base/store-auth-code record)
+        (is (= record (base/fetch-auth-code (:code record))))
+        (is (= 1 (count (base/auth-codes))) "added one"))))

--- a/test/clauth/test/auth_code.clj
+++ b/test/clauth/test/auth_code.clj
@@ -19,13 +19,13 @@
   (is (= 0 (count (base/auth-codes))) "starts out empty")
   (let [record (base/create-auth-code "my-client" "my-user"
                                       "http://test.com/redirect")]
-    (is (= "my-client" ( :client record )) "should have client")
-    (is (= "my-user" ( :subject record )) "should have subject")
-    (is (= "http://test.com/redirect" ( :redirect-uri record ))
+    (is (= "my-client" (:client record)) "should have client")
+    (is (= "my-user" (:subject record)) "should have subject")
+    (is (= "http://test.com/redirect" (:redirect-uri record))
         "should have redirect-uri")
-    (is (not (nil? (:code record ))) "should include auth-code field")
-    (is (= 1 (count (base/auth-codes ))) "added one")
-    (is (= record (first (base/auth-codes ))) "added one")
+    (is (not (nil? (:code record))) "should include auth-code field")
+    (is (= 1 (count (base/auth-codes))) "added one")
+    (is (= record (first (base/auth-codes))) "added one")
     (is (= record (base/find-valid-auth-code (:code record))))))
 
 (deftest auth-code-validity

--- a/test/clauth/test/auth_code.clj
+++ b/test/clauth/test/auth_code.clj
@@ -4,42 +4,42 @@
         [clojure.test])
   (:require [clj-time.core :as time]))
 
-   (deftest auth-code-records
-     (let 
-        [record (oauth-code "my-client" "user" "http://test.com/redirect")]
-        (is (= "my-client" ( :client record )) "should have client")
-        (is (= "user" ( :subject record )) "should have subject")
-        (is (= "http://test.com/redirect" ( :redirect-uri record )) "should have redirect-uri")
-        (is (not (nil? (:code record  ))) "should include code field")
-        (is (is-valid? record) "should be valid by default")))
+(deftest auth-code-records
+  (let [record (oauth-code "my-client" "user" "http://test.com/redirect")]
+    (is (= "my-client" (:client record)) "should have client")
+    (is (= "user" (:subject record)) "should have subject")
+    (is (= "http://test.com/redirect" (:redirect-uri record))
+        "should have redirect-uri")
+    (is (not (nil? (:code record))) "should include code field")
+    (is (is-valid? record) "should be valid by default")))
 
-   (deftest auth-code-creation
-     (reset-auth-code-store!)
-     (is (= 0 (count (auth-codes))) "starts out empty")
-     (let 
-        [record (create-auth-code "my-client" "my-user" "http://test.com/redirect")]
-        (is (= "my-client" ( :client record )) "should have client")
-        (is (= "my-user" ( :subject record )) "should have subject")
-        (is (= "http://test.com/redirect" ( :redirect-uri record )) "should have redirect-uri")
-        (is (not (nil? (:code record ))) "should include auth-code field")
-        (is (= 1 (count (auth-codes ))) "added one")
-        (is (= record (first (auth-codes ))) "added one")
-        (is (= record (find-valid-auth-code (:code record))))))
+(deftest auth-code-creation
+  (reset-auth-code-store!)
+  (is (= 0 (count (auth-codes))) "starts out empty")
+  (let [record (create-auth-code "my-client" "my-user"
+                                 "http://test.com/redirect")]
+    (is (= "my-client" ( :client record )) "should have client")
+    (is (= "my-user" ( :subject record )) "should have subject")
+    (is (= "http://test.com/redirect" ( :redirect-uri record ))
+        "should have redirect-uri")
+    (is (not (nil? (:code record ))) "should include auth-code field")
+    (is (= 1 (count (auth-codes ))) "added one")
+    (is (= record (first (auth-codes ))) "added one")
+    (is (= record (find-valid-auth-code (:code record))))))
 
-   (deftest auth-code-validity
-      (is (is-valid? {}) "by default it's valid")
-      (is (not (is-valid? nil)) "nil is always false")
-      (is (is-valid? {:expires (time/plus (time/now) (time/days 1))}) "valid if expiry date is in the future")
-      (is (not (is-valid? {:expires (time/date-time 2012 3 13)})) "expires if past expiry date")
-    )
+(deftest auth-code-validity
+  (is (is-valid? {}) "by default it's valid")
+  (is (not (is-valid? nil)) "nil is always false")
+  (is (is-valid? {:expires (time/plus (time/now) (time/days 1))})
+      "valid if expiry date is in the future")
+  (is (not (is-valid? {:expires (time/date-time 2012 3 13)}))
+      "expires if past expiry date"))
 
-   (deftest auth-code-store-implementation
-     (reset-auth-code-store!)
-     (is (= 0 (count (auth-codes))) "starts out empty")
-     (let 
-        [record (oauth-code "my-client" "my-user" "http://test.com/redirect")]
-        (is (nil? (fetch-auth-code (:code record))))
-        (do
-          (store-auth-code record)
-          (is (= record (fetch-auth-code (:code record))))
-          (is (= 1 (count (auth-codes))) "added one"))))
+(deftest auth-code-store-implementation
+  (reset-auth-code-store!)
+  (is (= 0 (count (auth-codes))) "starts out empty")
+  (let [record (oauth-code "my-client" "my-user" "http://test.com/redirect")]
+    (is (nil? (fetch-auth-code (:code record))))
+    (do (store-auth-code record)
+        (is (= record (fetch-auth-code (:code record))))
+        (is (= 1 (count (auth-codes))) "added one"))))

--- a/test/clauth/test/client.clj
+++ b/test/clauth/test/client.clj
@@ -2,29 +2,29 @@
   (:use [clauth.client]
         [clojure.test]))
 
-   (deftest client-registration
-     (reset-client-store!)
-     (let 
-        [ record (register-client "Super company inc" "http://example.com")
-          client-id (:client-id record )
-          client-secret (:client-secret record )]
+(deftest client-registration
+  (reset-client-store!)
+  (let [record (register-client "Super company inc" "http://example.com")
+        client-id (:client-id record)
+        client-secret (:client-secret record)]
+    (is (= "Super company inc" (:name record ))
+        "should add extra attributes to client")
+    (is (not (nil? client-id )) "should include client_id field")
+    (is (not (nil? client-secret )) "should include client_secret field")
+    (is (= 1 (count (clients))) "added one")
+    (is (= record (first (clients))) "added one")
+    (is (= record (authenticate-client client-id client-secret))
+        "should authenticate client")
+    (is (nil? (authenticate-client client-id "bad"))
+        "should not authenticate client with wrong password")
+    (is (nil? (authenticate-client "idontexist" "bad"))
+        "should not authenticate client with wrong id")))
 
-        (is (= "Super company inc" (:name record )) "should add extra attributes to client")
-        (is (not (nil? client-id )) "should include client_id field")
-        (is (not (nil? client-secret )) "should include client_secret field")
-        (is (= 1 (count (clients))) "added one")
-        (is (= record (first (clients))) "added one")
-        (is (= record (authenticate-client client-id client-secret)) "should authenticate client")
-        (is (nil? (authenticate-client client-id "bad")) "should not authenticate client with wrong password")
-        (is (nil? (authenticate-client "idontexist" "bad")) "should not authenticate client with wrong id")))
-
-   (deftest client-store-implementation
-     (reset-client-store!)
-     (is (= 0 (count (clients))) "starts out empty")
-     (let 
-        [ record (client-app)]
-        (is (nil? (fetch-client (:client-id record))))
-        (do
-          (store-client record)
-          (is (= record (fetch-client (:client-id record))))
-          (is (= 1 (count (clients))) "added one"))))
+(deftest client-store-implementation
+  (reset-client-store!)
+  (is (= 0 (count (clients))) "starts out empty")
+  (let [record (client-app)]
+    (is (nil? (fetch-client (:client-id record))))
+    (do (store-client record)
+        (is (= record (fetch-client (:client-id record))))
+        (is (= 1 (count (clients))) "added one"))))

--- a/test/clauth/test/client.clj
+++ b/test/clauth/test/client.clj
@@ -1,30 +1,30 @@
 (ns clauth.test.client
-  (:use [clauth.client]
-        [clojure.test]))
+  (:require  [clojure.test :refer :all]
+             [clauth.client :as base]))
 
 (deftest client-registration
-  (reset-client-store!)
-  (let [record (register-client "Super company inc" "http://example.com")
+  (base/reset-client-store!)
+  (let [record (base/register-client "Super company inc" "http://example.com")
         client-id (:client-id record)
         client-secret (:client-secret record)]
     (is (= "Super company inc" (:name record ))
         "should add extra attributes to client")
     (is (not (nil? client-id )) "should include client_id field")
     (is (not (nil? client-secret )) "should include client_secret field")
-    (is (= 1 (count (clients))) "added one")
-    (is (= record (first (clients))) "added one")
-    (is (= record (authenticate-client client-id client-secret))
+    (is (= 1 (count (base/clients))) "added one")
+    (is (= record (first (base/clients))) "added one")
+    (is (= record (base/authenticate-client client-id client-secret))
         "should authenticate client")
-    (is (nil? (authenticate-client client-id "bad"))
+    (is (nil? (base/authenticate-client client-id "bad"))
         "should not authenticate client with wrong password")
-    (is (nil? (authenticate-client "idontexist" "bad"))
+    (is (nil? (base/authenticate-client "idontexist" "bad"))
         "should not authenticate client with wrong id")))
 
 (deftest client-store-implementation
-  (reset-client-store!)
-  (is (= 0 (count (clients))) "starts out empty")
-  (let [record (client-app)]
-    (is (nil? (fetch-client (:client-id record))))
-    (do (store-client record)
-        (is (= record (fetch-client (:client-id record))))
-        (is (= 1 (count (clients))) "added one"))))
+  (base/reset-client-store!)
+  (is (= 0 (count (base/clients))) "starts out empty")
+  (let [record (base/client-app)]
+    (is (nil? (base/fetch-client (:client-id record))))
+    (do (base/store-client record)
+        (is (= record (base/fetch-client (:client-id record))))
+        (is (= 1 (count (base/clients))) "added one"))))

--- a/test/clauth/test/client.clj
+++ b/test/clauth/test/client.clj
@@ -7,10 +7,10 @@
   (let [record (base/register-client "Super company inc" "http://example.com")
         client-id (:client-id record)
         client-secret (:client-secret record)]
-    (is (= "Super company inc" (:name record ))
+    (is (= "Super company inc" (:name record))
         "should add extra attributes to client")
-    (is (not (nil? client-id )) "should include client_id field")
-    (is (not (nil? client-secret )) "should include client_secret field")
+    (is (not (nil? client-id)) "should include client_id field")
+    (is (not (nil? client-secret)) "should include client_secret field")
     (is (= 1 (count (base/clients))) "added one")
     (is (= record (first (base/clients))) "added one")
     (is (= record (base/authenticate-client client-id client-secret))

--- a/test/clauth/test/endpoints.clj
+++ b/test/clauth/test/endpoints.clj
@@ -50,8 +50,8 @@
                                     (.encodeAsString
                                      (Base64.)
                                      (.getBytes
-                                      (str (:client-id client ) ":"
-                                           (:client-secret client )))))}})
+                                      (str (:client-id client) ":"
+                                           (:client-secret client)))))}})
            {:status 200
             :headers {"Content-Type" "application/json"}
             :body (str "{\"access_token\":\"" (:token (first (tokens)))
@@ -201,7 +201,7 @@
       (is (= (handler {:params {:grant_type "authorization_code"
                                 :code (:code code)
                                 :redirect_uri redirect_uri
-                                :client_id (:client-id other )
+                                :client_id (:client-id other)
                                 :client_secret (:client-secret other)}})
                 {:status 400
                  :headers {"Content-Type" "application/json"}
@@ -210,7 +210,7 @@
 
       (is (= (handler {:params {:grant_type "authorization_code"
                                 :code (:code code)
-                                :client_id (:client-id client )
+                                :client_id (:client-id client)
                                 :client_secret (:client-secret client)}})
 
              {:status 400
@@ -231,7 +231,7 @@
 
     (is (= (handler {:params {:grant_type "authorization_code"
                               :redirect_uri redirect_uri
-                              :client_id (:client-id client )
+                              :client_id (:client-id client)
                               :client_secret (:client-secret client)}})
 
            {:status 400
@@ -281,7 +281,7 @@
                              :params params
                              :uri uri
                              :query-string query-string
-                             :session {:access_token (:token session_token )}})]
+                             :session {:access_token (:token session_token)}})]
       (is (= (response :status) 200)))
 
     (let [response (handler {:request-method :get
@@ -363,13 +363,13 @@
   (reset-token-store!)
   (client/reset-client-store!)
   (user/reset-user-store!)
-  (let [ handler (base/authorization-handler)
+  (let [handler (base/authorization-handler)
         client (client/register-client)
         user   (user/register-user "john@example.com" "password")
         redirect_uri "http://test.com"
         uri "/authorize"
         params {:response_type "token"
-                :client_id ( :client-id client )
+                :client_id (:client-id client)
                 :redirect_uri redirect_uri
                 :state "abcde"
                 :scope "calendar"}
@@ -410,7 +410,7 @@
                              :params (dissoc params :client_id)
                              :uri uri
                              :query-string query-string
-                             :session {:access_token (:token session_token )}})]
+                             :session {:access_token (:token session_token)}})]
       (is (= (response :status) 302))
       (is (= (response :headers)
              {"Location" "http://test.com#state=abcde&error=invalid_request"})
@@ -432,7 +432,7 @@
                              :params (assoc params :response_type "unsupported")
                              :uri uri
                              :query-string query-string
-                             :session {:access_token (:token session_token )}})]
+                             :session {:access_token (:token session_token)}})]
       (is (= (response :status) 302))
       (is (= (response :headers)
              {"Location"

--- a/test/clauth/test/endpoints.clj
+++ b/test/clauth/test/endpoints.clj
@@ -6,529 +6,528 @@
         [hiccup.util])
   (:import [org.apache.commons.codec.binary Base64]))
 
-    (deftest token-decoration
-        (is (= (decorate-token { :token "SECRET" :unimportant "forget this"})
-            { :access_token "SECRET" :token_type "bearer"})))
+(deftest token-decoration
+  (is (= (decorate-token {:token "SECRET" :unimportant "forget this"})
+         {:access_token "SECRET" :token_type "bearer"})))
 
-    (deftest token-ring-response
-        (is (= (token-response { :token "SECRET" :unimportant "forget this"})
-            { :status 200
-              :headers {"Content-Type" "application/json"}
-              :body "{\"access_token\":\"SECRET\",\"token_type\":\"bearer\"}"})))
+(deftest token-ring-response
+  (is (= (token-response {:token "SECRET" :unimportant "forget this"})
+         {:status 200
+          :headers {"Content-Type" "application/json"}
+          :body "{\"access_token\":\"SECRET\",\"token_type\":\"bearer\"}"})))
 
-    (deftest ring-error-response
-        (is (= (error-response :invalid_request)
-            { :status 400
-              :headers {"Content-Type" "application/json"}
-              :body "{\"error\":\"invalid_request\"}"})))
+(deftest ring-error-response
+  (is (= (error-response :invalid_request)
+         {:status 400
+          :headers {"Content-Type" "application/json"}
+          :body "{\"error\":\"invalid_request\"}"})))
 
-    (deftest extract-basic-authenticated-credentials
-        (is (= ["user" "password"] (basic-authentication-credentials { :headers {"authorization" "Basic dXNlcjpwYXNzd29yZA=="}}))))
+(deftest extract-basic-authenticated-credentials
+  (is (= ["user" "password"]
+         (basic-authentication-credentials
+          {:headers {"authorization" "Basic dXNlcjpwYXNzd29yZA=="}}))))
 
-    (deftest requesting-client-owner-token
-        (reset-token-store!)
-        (clauth.client/reset-client-store!)
-        (let [ handler (token-handler)
-               client (clauth.client/register-client)]
+(deftest requesting-client-owner-token
+  (reset-token-store!)
+  (clauth.client/reset-client-store!)
+  (let [handler (token-handler)
+        client (clauth.client/register-client)]
+    (is (= (handler {:params {:grant_type "client_credentials"
+                              :client_id (:client-id client)
+                              :client_secret (:client-secret client)}})
+           {:status 200
+            :headers {"Content-Type" "application/json"}
+            :body (str "{\"access_token\":\"" (:token (first (tokens)))
+                       "\",\"token_type\":\"bearer\"}")})
+        "url form encoded client credentials")
 
-            (is (= (handler { 
-                    :params {
-                        :grant_type "client_credentials"
-                        :client_id (:client-id client )
-                        :client_secret (:client-secret client)}})
-                { :status 200
-                  :headers {"Content-Type" "application/json"}
-                  :body (str "{\"access_token\":\"" ( :token (first (tokens))) "\",\"token_type\":\"bearer\"}") }) "url form encoded client credentials")
-
-            (is (= (handler { 
-                    :params { :grant_type "client_credentials" }
-                    :headers {"authorization" 
-                    (str "Basic " (.encodeAsString (Base64.) (.getBytes (str (:client-id client ) ":" (:client-secret client )))))}})
-                { :status 200
-                  :headers {"Content-Type" "application/json"}
-                  :body (str "{\"access_token\":\"" (:token (first (tokens)) ) "\",\"token_type\":\"bearer\"}") }) "basic authenticated client credentials")
+    (is (= (handler {:params { :grant_type "client_credentials" }
+                     :headers {"authorization"
+                               (str "Basic "
+                                    (.encodeAsString
+                                     (Base64.)
+                                     (.getBytes
+                                      (str (:client-id client ) ":"
+                                           (:client-secret client )))))}})
+           {:status 200
+            :headers {"Content-Type" "application/json"}
+            :body (str "{\"access_token\":\"" (:token (first (tokens)))
+                       "\",\"token_type\":\"bearer\"}")})
+        "basic authenticated client credentials")
 
 
-            (is (= (handler { 
-                    :params {
-                        :grant_type "client_credentials"
-                        :client_id  "bad"
-                        :client_secret "client"}})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_client\"}"}) "should fail on bad client authentication") 
+    (is (= (handler {:params {:grant_type "client_credentials"
+                              :client_id  "bad"
+                              :client_secret "client"}})
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"invalid_client\"}"})
+        "should fail on bad client authentication")
 
-            (is (= (handler { :params { :grant_type "client_credentials"}})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_client\"}"}) "should fail with missing client authentication") ))
+    (is (= (handler {:params { :grant_type "client_credentials"}})
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"invalid_client\"}"})
+        "should fail with missing client authentication")))
 
-    (deftest requesting-resource-owner-password-credentials-token
-        (reset-token-store!)
-        (clauth.client/reset-client-store!)
-        (clauth.user/reset-user-store!)
-        (let [ handler (token-handler)
-               client (clauth.client/register-client)
-               user   (clauth.user/register-user "john@example.com" "password")]
+(deftest requesting-resource-owner-password-credentials-token
+  (reset-token-store!)
+  (clauth.client/reset-client-store!)
+  (clauth.user/reset-user-store!)
+  (let [handler (token-handler)
+        client (clauth.client/register-client)
+        user (clauth.user/register-user "john@example.com" "password")]
+    (is (= (handler {:params {:grant_type "password"
+                              :username "john@example.com"
+                              :password "password"
+                              :client_id (:client-id client)
+                              :client_secret (:client-secret client)}})
+           {:status 200
+            :headers {"Content-Type" "application/json"}
+            :body (str "{\"access_token\":\"" (:token (first (tokens)))
+                       "\",\"token_type\":\"bearer\"}")})
+        "url form encoded client credentials")
 
-            (is (= (handler { 
-                    :params {
-                        :grant_type "password"
-                        :username "john@example.com"
-                        :password "password"
-                        :client_id (:client-id client )
-                        :client_secret (:client-secret client)}})
-                { :status 200
-                  :headers {"Content-Type" "application/json"}
-                  :body (str "{\"access_token\":\"" ( :token (first (tokens))) "\",\"token_type\":\"bearer\"}") }) "url form encoded client credentials")
-
-            (is (= (handler { 
-                    :params { :grant_type "password" 
+    (is (= (handler {:params {:grant_type "password"
                               :username "john@example.com"
                               :password "password"}
-                    :headers {"authorization" 
-                    (str "Basic " (.encodeAsString (Base64.) (.getBytes (str (:client-id client ) ":" (:client-secret client )))))}})
-                { :status 200
-                  :headers {"Content-Type" "application/json"}
-                  :body (str "{\"access_token\":\"" (:token (first (tokens)) ) "\",\"token_type\":\"bearer\"}") }) "basic authenticated client credentials")
+                     :headers {"authorization"
+                               (format "Basic %s"
+                                       (.encodeAsString
+                                        (Base64.)
+                                        (.getBytes
+                                         (format "%s:%s"
+                                                 (:client-id client)
+                                                 (:client-secret client)))))}})
+           {:status 200
+            :headers {"Content-Type" "application/json"}
+            :body (str "{\"access_token\":\"" (:token (first (tokens)))
+                       "\",\"token_type\":\"bearer\"}")})
+        "basic authenticated client credentials")
 
-            (is (= (handler { 
-                    :params {
-                        :grant_type "password"
-                        :username "john@example.com"
-                        :password "not my password"
-                        :client_id (:client-id client )
-                        :client_secret (:client-secret client)}})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_grant\"}"}) "should fail on bad user password") 
+    (is (= (handler {:params {:grant_type "password"
+                              :username "john@example.com"
+                              :password "not my password"
+                              :client_id (:client-id client)
+                              :client_secret (:client-secret client)}})
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"invalid_grant\"}"})
+        "should fail on bad user password")
 
-            (is (= (handler { :params { :grant_type "password"                        
-                                        :client_id (:client-id client )
-                                        :client_secret (:client-secret client)}})
+    (is (= (handler {:params {:grant_type "password"
+                              :client_id (:client-id client)
+                              :client_secret (:client-secret client)}})
 
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_grant\"}"}) "should fail with missing user authentication") 
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"invalid_grant\"}"})
+        "should fail with missing user authentication")
 
+    (is (= (handler {:params {:grant_type "password"
+                              :username "john@example.com"
+                              :password "password"
+                              :client_id  "bad"
+                              :client_secret "client"}})
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"invalid_client\"}"})
+        "should fail on bad client authentication")
 
-            (is (= (handler { 
-                    :params {
-                        :grant_type "password"
-                        :username "john@example.com"
-                        :password "password"
-                        :client_id  "bad"
-                        :client_secret "client"}})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_client\"}"}) "should fail on bad client authentication") 
+    (is (= (handler { :params {:grant_type "password"}})
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"invalid_client\"}"})
+        "should fail with missing client authentication")))
 
-            (is (= (handler { :params { :grant_type "password"}})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_client\"}"}) "should fail with missing client authentication") ))
-
-    (deftest requesting-authorization-code-token
-        (reset-token-store!)
-        (reset-auth-code-store!)
-        (clauth.client/reset-client-store!)
-        (clauth.user/reset-user-store!)
-        (let [ handler (token-handler)
-               client (clauth.client/register-client)
-               user   (clauth.user/register-user "john@example.com" "password")
-               scope "calendar"
-               redirect_uri "http://test.com/redirect_uri"
-               object {:id "stuff"}
-               ]
-            (let [ code   (create-auth-code client user redirect_uri scope object)]
-              (is (= (handler { 
-                      :params {
-                          :grant_type "authorization_code"
-                          :code (:code code)
-                          :redirect_uri redirect_uri
-                          :client_id (:client-id client )
-                          :client_secret (:client-secret client)}})
-                  { :status 200
-                    :headers {"Content-Type" "application/json"}
-                    :body (str "{\"access_token\":\"" ( :token (first (tokens))) "\",\"token_type\":\"bearer\"}") }) 
-                "url form encoded client credentials" ))
-
-            (let [ code   (create-auth-code client user redirect_uri "calendar" object)]
-              (is (= (handler { 
-                      :params { 
-                          :grant_type "authorization_code"
-                          :redirect_uri redirect_uri
-                          :code (:code code)
-                      }
-                      :headers { "authorization" 
-                        (str "Basic " (.encodeAsString (Base64.) (.getBytes (str (:client-id client ) ":" (:client-secret client )))))}})
-                  { :status 200
-                    :headers {"Content-Type" "application/json"}
-                    :body (str "{\"access_token\":\"" (:token (first (tokens)) ) "\",\"token_type\":\"bearer\"}") }) 
-                "basic authenticated client credentials"))
-
-            (let [ code   (create-auth-code client user redirect_uri "calendar" object)]
-              (is (= (handler { 
-                    :params {
-                        :grant_type "authorization_code"
-                        :code (:code code)
-                        :redirect_uri redirect_uri
-                        :client_id (:client-id client )
-                        :client_secret "bad"}})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_client\"}"}) 
-              "should fail on bad client authentication"))
-
-            (let [ code   (create-auth-code client user redirect_uri "calendar" object)
-                   other (clauth.client/register-client)]
-              (is (= (handler { 
-                    :params {
-                        :grant_type "authorization_code"
-                        :code (:code code)
-                        :redirect_uri redirect_uri
-                        :client_id (:client-id other )
-                        :client_secret (:client-secret other)}})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_grant\"}"}) 
-              "should fail for other client")
-
-
-              (is (= (handler { :params { 
-                                  :grant_type "authorization_code"
-                                  :code (:code code)
-                                  :client_id (:client-id client )
-                                  :client_secret (:client-secret client)}})
-
-                  { :status 400
-                    :headers {"Content-Type" "application/json"}
-                    :body "{\"error\":\"invalid_grant\"}"}) 
-                "should fail with missing redirect_uri") 
-
-              (is (= (handler { :params { 
-                                  :grant_type "authorization_code"
-                                  :code (:code code)
-                                  :redirect_uri "http://badsite.com"
-                                  :client_id (:client-id client )
-                                  :client_secret (:client-secret client)}})
-
-                  { :status 400
-                    :headers {"Content-Type" "application/json"}
-                    :body "{\"error\":\"invalid_grant\"}"}) 
-                "should fail with wrong redirect_uri" ))
-
-            (is (= (handler { :params { 
-                                :grant_type "authorization_code"
+(deftest requesting-authorization-code-token
+  (reset-token-store!)
+  (reset-auth-code-store!)
+  (clauth.client/reset-client-store!)
+  (clauth.user/reset-user-store!)
+  (let [handler (token-handler)
+        client (clauth.client/register-client)
+        user (clauth.user/register-user "john@example.com" "password")
+        scope "calendar"
+        redirect_uri "http://test.com/redirect_uri"
+        object {:id "stuff"}]
+    (let [code (create-auth-code client user redirect_uri scope object)]
+      (is (= (handler {:params {:grant_type "authorization_code"
+                                :code (:code code)
                                 :redirect_uri redirect_uri
+                                :client_id (:client-id client)
+                                :client_secret (:client-secret client)}})
+             {:status 200
+              :headers {"Content-Type" "application/json"}
+              :body (str "{\"access_token\":\"" (:token (first (tokens)))
+                         "\",\"token_type\":\"bearer\"}")})
+          "url form encoded client credentials"))
+
+    (let [code (create-auth-code client user redirect_uri "calendar" object)]
+      (is (= (handler {:params {:grant_type "authorization_code"
+                                :redirect_uri redirect_uri
+                                :code (:code code)}
+                       :headers {"authorization"
+                                 (format "Basic %s"
+                                         (.encodeAsString
+                                          (Base64.)
+                                          (.getBytes
+                                           (format "%s:%s"
+                                                   (:client-id client)
+                                                   (:client-secret
+                                                    client)))))}})
+             {:status 200
+              :headers {"Content-Type" "application/json"}
+              :body (str "{\"access_token\":\"" (:token (first (tokens)))
+                         "\",\"token_type\":\"bearer\"}")})
+          "basic authenticated client credentials"))
+
+    (let [code (create-auth-code client user redirect_uri "calendar" object)]
+      (is (= (handler {:params {:grant_type "authorization_code"
+                                :code (:code code)
+                                :redirect_uri redirect_uri
+                                :client_id (:client-id client)
+                                :client_secret "bad"}})
+             {:status 400
+              :headers {"Content-Type" "application/json"}
+              :body "{\"error\":\"invalid_client\"}"})
+          "should fail on bad client authentication"))
+
+    (let [code (create-auth-code client user redirect_uri "calendar" object)
+          other (clauth.client/register-client)]
+      (is (= (handler {:params {:grant_type "authorization_code"
+                                :code (:code code)
+                                :redirect_uri redirect_uri
+                                :client_id (:client-id other )
+                                :client_secret (:client-secret other)}})
+                {:status 400
+                 :headers {"Content-Type" "application/json"}
+                 :body "{\"error\":\"invalid_grant\"}"})
+          "should fail for other client")
+
+      (is (= (handler {:params {:grant_type "authorization_code"
+                                :code (:code code)
                                 :client_id (:client-id client )
                                 :client_secret (:client-secret client)}})
 
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_grant\"}"}) 
-              "should fail with missing code") 
+             {:status 400
+              :headers {"Content-Type" "application/json"}
+              :body "{\"error\":\"invalid_grant\"}"})
+          "should fail with missing redirect_uri")
 
-            (let [ code   (create-auth-code client user redirect_uri "calendar" object)]
-              (is (= (handler { 
-                      :params {
-                          :grant_type "authorization_code"
-                          :code (:code code)
-                          :redirect_uri redirect_uri
-                          :client_id  "bad"
-                          :client_secret "client"}})
-                  { :status 400
-                    :headers {"Content-Type" "application/json"}
-                    :body "{\"error\":\"invalid_client\"}"}) "should fail on bad client authentication"))
+      (is (= (handler {:params {:grant_type "authorization_code"
+                                :code (:code code)
+                                :redirect_uri "http://badsite.com"
+                                :client_id (:client-id client)
+                                :client_secret (:client-secret client)}})
 
-            (let [ code   (create-auth-code client user redirect_uri "calendar" object)]
-              (is (= (handler { :params { 
-                                  :grant_type "authorization_code" 
-                                  :code (:code code) 
-                                  :redirect_uri redirect_uri }})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"invalid_client\"}"}) "should fail with missing client authentication") )))
+             {:status 400
+              :headers {"Content-Type" "application/json"}
+              :body "{\"error\":\"invalid_grant\"}"})
+          "should fail with wrong redirect_uri"))
 
-    (deftest requesting-authorization-code
-        (reset-token-store!)
-        (reset-auth-code-store!)
-        (clauth.client/reset-client-store!)
-        (clauth.user/reset-user-store!)
-        (let [ handler (authorization-handler)
-               client (clauth.client/register-client)
-               user   (clauth.user/register-user "john@example.com" "password")
-               redirect_uri "http://test.com"
-               uri "/authorize"
-               params {
-                        :response_type "code"
-                        :client_id ( :client-id client )
-                        :redirect_uri redirect_uri
-                        :state "abcde"
-                        :scope "calendar"}
-              query-string (url-encode params)]
+    (is (= (handler {:params {:grant_type "authorization_code"
+                              :redirect_uri redirect_uri
+                              :client_id (:client-id client )
+                              :client_secret (:client-secret client)}})
 
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params params 
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 200)))
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"invalid_grant\"}"})
+        "should fail with missing code")
 
-            (let [ response (handler { 
-                    :request-method :get
-                    :uri uri
-                    :query-string query-string
-                    :headers {"accept" "text/html"}
-                    :params params })
-                   session (response :session)]
-                          (is (= (response :status) 302))
-                          (is (= (session :return-to) 
-                            (str uri "?" query-string)))
-                          (is (= (response :headers) {"Location" "/login"})))
-            ;; Missing parameters
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params (dissoc params :response_type)
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 302))
-              (is (= (response :headers) { "Location" "http://test.com?state=abcde&error=invalid_request" })))
-            
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params (dissoc params :client_id)
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 302))
-              (is (= (response :headers) { "Location" "http://test.com?state=abcde&error=invalid_request" }) "should redirect with error in query"))
+    (let [code (create-auth-code client user redirect_uri "calendar" object)]
+      (is (= (handler {:params {:grant_type "authorization_code"
+                                :code (:code code)
+                                :redirect_uri redirect_uri
+                                :client_id "bad"
+                                :client_secret "client"}})
+             {:status 400
+              :headers {"Content-Type" "application/json"}
+              :body "{\"error\":\"invalid_client\"}"})
+          "should fail on bad client authentication"))
 
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params (dissoc params :client_id :state)
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 302))
-              (is (= (response :headers) { "Location" "http://test.com?error=invalid_request" }) "should redirect with error in query"))
+    (let [code (create-auth-code client user redirect_uri "calendar" object)]
+      (is (= (handler {:params {:grant_type "authorization_code"
+                                :code (:code code)
+                                :redirect_uri redirect_uri}})
+             {:status 400
+              :headers {"Content-Type" "application/json"}
+              :body "{\"error\":\"invalid_client\"}"})
+          "should fail with missing client authentication"))))
 
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params (assoc params :response_type "unsupported")
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 302))
-              (is (= (response :headers) { "Location" "http://test.com?state=abcde&error=unsupported_response_type" }) "should return error on unsupported response type"))
+(deftest requesting-authorization-code
+  (reset-token-store!)
+  (reset-auth-code-store!)
+  (clauth.client/reset-client-store!)
+  (clauth.user/reset-user-store!)
+  (let [handler (authorization-handler)
+        client (clauth.client/register-client)
+        user (clauth.user/register-user "john@example.com" "password")
+        redirect_uri "http://test.com"
+        uri "/authorize"
+        params {:response_type "code"
+                :client_id (:client-id client)
+                :redirect_uri redirect_uri
+                :state "abcde"
+                :scope "calendar"}
+        query-string (url-encode params)]
 
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params params
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token )}})]
+      (is (= (response :status) 200)))
 
-            (let [ session_token (create-token client user)
-                   params (assoc params :csrf-token "csrftoken")
-                   response (handler { 
-                    :request-method :post
-                    :params params 
-                    :uri uri
-                    :query-string query-string
-                    :session { 
-                      :access_token ( :token session_token )
-                      :csrf-token "csrftoken" }})
-                   post_auth_redirect_uri ((response :headers) "Location")
-                   code_string (last (re-find #"code=([^&]+)" post_auth_redirect_uri ))
-                   auth-code (fetch-auth-code code_string)]
-              (is (= (response :status) 302))
-              (is (= post_auth_redirect_uri (str "http://test.com?state=abcde&code=" code_string )) "should redirect with proper format")
-              (is (= (:client auth-code) client) "should properly set client")
-              (is (= (:subject auth-code) user) "should properly set subject")
-              (is (= (:redirect-uri auth-code) redirect_uri) "should properly save redirect_uri")
-            )))
+    (let [response (handler {:request-method :get
+                             :uri uri
+                             :query-string query-string
+                             :headers {"accept" "text/html"}
+                             :params params})
+          session (response :session)]
+      (is (= (response :status) 302))
+      (is (= (session :return-to)
+             (str uri "?" query-string)))
+      (is (= (response :headers) {"Location" "/login"})))
+    ;; Missing parameters
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params (dissoc params :response_type)
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)}})]
+      (is (= (response :status) 302))
+      (is (= (response :headers)
+             {"Location" "http://test.com?state=abcde&error=invalid_request"})))
 
-    (deftest requesting-implicit-authorization
-        (reset-token-store!)
-        (clauth.client/reset-client-store!)
-        (clauth.user/reset-user-store!)
-        (let [ handler (authorization-handler)
-               client (clauth.client/register-client)
-               user   (clauth.user/register-user "john@example.com" "password")
-               redirect_uri "http://test.com"
-               uri "/authorize"
-               params {
-                        :response_type "token"
-                        :client_id ( :client-id client )
-                        :redirect_uri redirect_uri
-                        :state "abcde"
-                        :scope "calendar"}
-              query-string (url-encode params)]
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params (dissoc params :client_id)
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)}})]
+      (is (= (response :status) 302))
+      (is (= (response :headers)
+             {"Location" "http://test.com?state=abcde&error=invalid_request"})
+          "should redirect with error in query"))
 
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params params 
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 200)))
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params (dissoc params :client_id :state)
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)}})]
+      (is (= (response :status) 302))
+      (is (= (response :headers)
+             {"Location" "http://test.com?error=invalid_request"})
+          "should redirect with error in query"))
 
-            (let [ response (handler { 
-                    :request-method :get
-                    :uri uri
-                    :query-string query-string
-                    :headers {"accept" "text/html"}
-                    :params params })
-                   session (response :session)]
-                          (is (= (response :status) 302))
-                          (is (= (session :return-to) 
-                            (str uri "?" query-string)))
-                          (is (= (response :headers) {"Location" "/login"})))
-            ;; Missing parameters
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params (dissoc params :response_type)
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 302))
-              (is (= (response :headers) { "Location" "http://test.com?state=abcde&error=invalid_request" })))
-            
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params (dissoc params :client_id)
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 302))
-              (is (= (response :headers) { "Location" "http://test.com#state=abcde&error=invalid_request" }) "should redirect with error in fragment"))
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params (assoc params :response_type "unsupported")
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)}})]
+      (is (= (response :status) 302))
+      (is (= (response :headers)
+             {"Location"
+              "http://test.com?state=abcde&error=unsupported_response_type"})
+          "should return error on unsupported response type"))
 
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params (dissoc params :client_id :state)
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 302))
-              (is (= (response :headers) { "Location" "http://test.com#error=invalid_request" }) "should redirect with error in fragment"))
+    (let [session_token (create-token client user)
+          params (assoc params :csrf-token "csrftoken")
+          response (handler {:request-method :post
+                             :params params
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)
+                                       :csrf-token "csrftoken"}})
+          post_auth_redirect_uri ((response :headers) "Location")
+          code_string (last (re-find #"code=([^&]+)" post_auth_redirect_uri))
+          auth-code (fetch-auth-code code_string)]
+      (is (= (response :status) 302))
+      (is (= post_auth_redirect_uri
+             (str "http://test.com?state=abcde&code=" code_string))
+          "should redirect with proper format")
+      (is (= (:client auth-code) client) "should properly set client")
+      (is (= (:subject auth-code) user) "should properly set subject")
+      (is (= (:redirect-uri auth-code) redirect_uri)
+          "should properly save redirect_uri"))))
 
-            (let [ session_token (create-token client user)
-                   response (handler { 
-                    :request-method :get
-                    :params (assoc params :response_type "unsupported")
-                    :uri uri
-                    :query-string query-string
-                    :session { :access_token ( :token session_token )}})]
-              (is (= (response :status) 302))
-              (is (= (response :headers) { "Location" "http://test.com?state=abcde&error=unsupported_response_type" }) "should return error on unsupported response type"))
+(deftest requesting-implicit-authorization
+  (reset-token-store!)
+  (clauth.client/reset-client-store!)
+  (clauth.user/reset-user-store!)
+  (let [ handler (authorization-handler)
+        client (clauth.client/register-client)
+        user   (clauth.user/register-user "john@example.com" "password")
+        redirect_uri "http://test.com"
+        uri "/authorize"
+        params {:response_type "token"
+                :client_id ( :client-id client )
+                :redirect_uri redirect_uri
+                :state "abcde"
+                :scope "calendar"}
+        query-string (url-encode params)]
 
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params params
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)}})]
+      (is (= (response :status) 200)))
 
-            (let [ session_token (create-token client user)
-                   params (assoc params :csrf-token "csrftoken")
-                   response (handler { 
-                    :request-method :post
-                    :params params 
-                    :uri uri
-                    :query-string query-string
-                    :session { 
-                      :access_token ( :token session_token )
-                      :csrf-token "csrftoken" }})
-                   redirect_uri ((response :headers) "Location")
-                   token_string (last (re-find #"access_token=([^&]+)" redirect_uri))
-                   token (fetch-token token_string)]
-              (is (= (response :status) 302))
-              (is (= redirect_uri (str "http://test.com#state=abcde&access_token=" token_string "&token_type=bearer" )) "should redirect with proper format")
-              (is (= (:client token) client) "should properly set client")
-              (is (= (:subject token) user) "should properly set subject")
-            )))
+    (let [response (handler {:request-method :get
+                             :uri uri
+                             :query-string query-string
+                             :headers {"accept" "text/html"}
+                             :params params})
+          session (response :session)]
+      (is (= (response :status) 302))
+      (is (= (session :return-to)
+             (str uri "?" query-string)))
+      (is (= (response :headers) {"Location" "/login"})))
 
-    (deftest requesting-unsupported-grant
-        (reset-token-store!)
-        (clauth.client/reset-client-store!)
-        (let [ handler (token-handler)
-               client (clauth.client/register-client)]
+    ;; Missing parameters
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params (dissoc params :response_type)
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)}})]
+      (is (= (response :status) 302))
+      (is (= (response :headers)
+             {"Location" "http://test.com?state=abcde&error=invalid_request"})))
 
-            (is (= (handler { :params { :grant_type "telepathy"}})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"unsupported_grant_type\"}"}) "should fail with unsupported grant type") 
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params (dissoc params :client_id)
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token )}})]
+      (is (= (response :status) 302))
+      (is (= (response :headers)
+             {"Location" "http://test.com#state=abcde&error=invalid_request"})
+          "should redirect with error in fragment"))
 
-            (is (= (handler { :params { }})
-                { :status 400
-                  :headers {"Content-Type" "application/json"}
-                  :body "{\"error\":\"unsupported_grant_type\"}"}) "should fail with missing grant type")))
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params (dissoc params :client_id :state)
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)}})]
+      (is (= (response :status) 302))
+      (is (= (response :headers)
+             {"Location" "http://test.com#error=invalid_request"})
+          "should redirect with error in fragment"))
 
+    (let [session_token (create-token client user)
+          response (handler {:request-method :get
+                             :params (assoc params :response_type "unsupported")
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token )}})]
+      (is (= (response :status) 302))
+      (is (= (response :headers)
+             {"Location"
+              "http://test.com?state=abcde&error=unsupported_response_type"})
+          "should return error on unsupported response type"))
 
-    (deftest interactive-login-session
-        (reset-token-store!)
-        (clauth.client/reset-client-store!)
-        (clauth.user/reset-user-store!)
-        (let [ client (clauth.client/register-client)
-               handler (login-handler {:login-form (fn [_] { :body "login form" } ) :client client})
-               user   (clauth.user/register-user "john@example.com" "password")]
+    (let [session_token (create-token client user)
+          params (assoc params :csrf-token "csrftoken")
+          response (handler {:request-method :post
+                             :params params
+                             :uri uri
+                             :query-string query-string
+                             :session {:access_token (:token session_token)
+                                       :csrf-token "csrftoken"}})
+          redirect_uri ((response :headers) "Location")
+          token_string (last (re-find #"access_token=([^&]+)" redirect_uri))
+          token (fetch-token token_string)]
+      (is (= (response :status) 302))
+      (is (= redirect_uri (str "http://test.com#state=abcde&access_token="
+                               token_string "&token_type=bearer"))
+          "should redirect with proper format")
+      (is (= (:client token) client) "should properly set client")
+      (is (= (:subject token) user) "should properly set subject"))))
 
-            (let [ response (handler { 
-                    :request-method :post
-                    :session {:csrf-token "csrftoken"}
-                    :params {
-                        :username "john@example.com"
-                        :password "password"
-                        :csrf-token "csrftoken"}})
-                   session (response :session)
-                   token-string (session :access_token)
-                   token (fetch-token token-string)]
-              (is (= 302 (response :status)) "Should redirect user")
-              (is (= "/" ((response :headers) "Location")) "Should redirect user to home")
-              (is (= user (:subject token)) "should set user to token")
-              (is (= client (:client token)) "should set client to token"))
+(deftest requesting-unsupported-grant
+  (reset-token-store!)
+  (clauth.client/reset-client-store!)
+  (let [handler (token-handler)
+        client (clauth.client/register-client)]
 
-            (let [ response (handler { 
-                    :request-method :post
-                    :session {:csrf-token "csrftoken" :return-to "/authorization"}
-                    :params {
-                        :username "john@example.com"
-                        :password "password"
-                        :csrf-token "csrftoken"}})
-                   session (response :session)
-                   token-string (session :access_token)
-                   token (fetch-token token-string)]
-              (is (= 302 (response :status)) "Should redirect user")
-              (is (= "/authorization" ((response :headers) "Location")) "Should redirect user to whatever is in the return-to session")
-              (is (nil? (session :return-to)) "Should remove return-to from session")
-              (is (= user (:subject token)) "should set user to token")
-              (is (= client (:client token)) "should set client to token"))
+    (is (= (handler {:params {:grant_type "telepathy"}})
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"unsupported_grant_type\"}"})
+        "should fail with unsupported grant type")
 
-            (let [ response (handler { 
-                    :request-method :get })]
-              (is (= ( response :body ) "login form") "should show login form"))
+    (is (= (handler {:params {}})
+           {:status 400
+            :headers {"Content-Type" "application/json"}
+            :body "{\"error\":\"unsupported_grant_type\"}"})
+        "should fail with missing grant type")))
 
-            (let [ response (handler { 
-                    :request-method :post
-                    :session {:csrf-token "csrftoken"}
-                    :params {
-                        :username "john@example.com"
-                        :password "wrong"
-                        :csrf-token "csrftoken"}})]
-              (is (= (response :body) "login form") "should show login form for wrong password"))))
+(deftest interactive-login-session
+  (reset-token-store!)
+  (clauth.client/reset-client-store!)
+  (clauth.user/reset-user-store!)
+  (let [client (clauth.client/register-client)
+        handler (login-handler {:login-form (fn [_] {:body "login form"})
+                                :client client})
+        user (clauth.user/register-user "john@example.com" "password")
+        response (handler {:request-method :post
+                           :session {:csrf-token "csrftoken"}
+                           :params {:username "john@example.com"
+                                    :password "password"
+                                    :csrf-token "csrftoken"}})
+        session (response :session)
+        token-string (session :access_token)
+        token (fetch-token token-string)]
+    (is (= 302 (response :status)) "Should redirect user")
+    (is (= "/" ((response :headers) "Location")) "Should redirect user to home")
+    (is (= user (:subject token)) "should set user to token")
+    (is (= client (:client token)) "should set client to token")
 
+    (let [response (handler {:request-method :post
+                             :session {:csrf-token "csrftoken"
+                                       :return-to "/authorization"}
+                             :params {:username "john@example.com"
+                                      :password "password"
+                                      :csrf-token "csrftoken"}})
+          session (response :session)
+          token-string (session :access_token)
+          token (fetch-token token-string)]
+      (is (= 302 (response :status)) "Should redirect user")
+      (is (= "/authorization" ((response :headers) "Location"))
+          "Should redirect user to whatever is in the return-to session")
+      (is (nil? (session :return-to)) "Should remove return-to from session")
+      (is (= user (:subject token)) "should set user to token")
+      (is (= client (:client token)) "should set client to token"))
 
-    (deftest login-helpers
-      (let [req {}]
-        (is (not (logged-in? req)) "should not be marked as logged in")
-        (is (nil? (current-user req)) "should not have a current user")
-        )
+    (let [response (handler {:request-method :get})]
+      (is (= (response :body) "login form") "should show login form"))
+    (let [response (handler {:request-method :post
+                             :session {:csrf-token "csrftoken"}
+                             :params {:username "john@example.com"
+                                      :password "wrong"
+                                      :csrf-token "csrftoken"}})]
+      (is (= (response :body) "login form")
+          "should show login form for wrong password"))))
 
-      (let [
-          client (clauth.client/register-client)
-          user   (clauth.user/register-user "john@example.com" "password")
-          session-token (create-token client user)
-          req { :access-token session-token}]
-        (is (logged-in? req) "should be marked as logged in")
-        (is (= (current-user req) user) "should have a current user")))
+(deftest login-helpers
+  (let [req {}]
+    (is (not (logged-in? req)) "should not be marked as logged in")
+    (is (nil? (current-user req)) "should not have a current user"))
+
+  (let [client (clauth.client/register-client)
+        user (clauth.user/register-user "john@example.com" "password")
+        session-token (create-token client user)
+        req {:access-token session-token}]
+    (is (logged-in? req) "should be marked as logged in")
+    (is (= (current-user req) user) "should have a current user")))
 

--- a/test/clauth/test/middleware.clj
+++ b/test/clauth/test/middleware.clj
@@ -1,80 +1,85 @@
 (ns clauth.test.middleware
-  (:use [clauth.middleware]
-        [clojure.test]))
+  (:require [clojure.test :refer :all]
+            [clauth.middleware :as base]))
 
 (deftest bearer-token-from-header
   ;; authorization success adds oauth-token on request map
-  (is (= "secrettoken" (:access-token
-                        ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
-                         {:headers {"authorization" "Bearer secrettoken"}})))
+  (is (= "secrettoken"
+         (:access-token
+          ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
+           {:headers {"authorization" "Bearer secrettoken"}})))
       "find matching token")
 
   (is (nil? (:access-token
-             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+             ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
               {:headers {"authorization" "Bearer wrongtoken"}})))
       "should only return matching token")
 
   (is (nil? (:access-token
-             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+             ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
               {:headers {}}))) "should not set if no token present"))
 
 (deftest bearer-token-from-params
   ;; authorization success adds oauth-token on request map
-  (is (= "secrettoken" (:access-token
-                        ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
-                         {:params {:access_token "secrettoken"}})))
+  (is (= "secrettoken"
+         (:access-token
+          ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
+           {:params {:access_token "secrettoken"}})))
       "find matching token")
 
   (is (nil? (:access-token
-             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+             ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
               { :params {:access_token "wrongtoken"}})))
       "should only return matching token")
 
   (is (nil? (:access-token
-             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+             ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
               {}))) "should not set if no token present"))
 
 (deftest bearer-token-from-cookies
   ;; authorization success adds oauth-token on request map
-  (is (= "secrettoken" (:access-token
-                        ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
-                         {:cookies {"access_token" { :value "secrettoken"}}})))
+  (is (= "secrettoken"
+         (:access-token
+          ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
+           {:cookies {"access_token" { :value "secrettoken"}}})))
       "find matching token")
 
   (is (nil? (:access-token
-             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+             ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
               {:cookies {"access_token" { :value "wrongtoken"}}})))
       "should only return matching token")
 
   (is (nil? (:access-token
-             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+             ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
               {}))) "should not set if no token present"))
 
 (deftest bearer-token-from-session
   ;; authorization success adds oauth-token on request map
-  (is (= "secrettoken" (:access-token
-                        ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
-                         {:session {:access_token "secrettoken"}})))
+  (is (= "secrettoken"
+         (:access-token
+          ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
+           {:session {:access_token "secrettoken"}})))
       "find matching token")
 
   (is (nil? (:access-token
-             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+             ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
               {:session {:access_token "wrongtoken"}})))
       "should only return matching token")
 
   (is (nil? (:access-token
-             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+             ((base/wrap-bearer-token (fn [req] req) #{"secrettoken"})
               {}))) "should not set if no token present"))
 
 (deftest require-token
   ;; authorization success adds oauth-token on request map
   (is (= 200 (:status
-              ((require-bearer-token! (fn [req] {:status 200}) #{"secrettoken"})
+              ((base/require-bearer-token!
+                (fn [req] {:status 200}) #{"secrettoken"})
                {:headers {"authorization" "Bearer secrettoken"}})))
       "find matching token")
 
-  (let [response ((require-bearer-token! (fn [req] {:status 200})
-                                         #{"secrettoken"})
+  (let [response ((base/require-bearer-token!
+                   (fn [req] {:status 200}) #{"secrettoken"})
                   {:headers {"accept" "text/html"}
                    :query-string "test=123"
                    :uri "/protected"})]
@@ -84,21 +89,24 @@
         "set return-to"))
 
   (is (= 401 (:status
-              ((require-bearer-token! (fn [req] {:status 200}) #{"secrettoken"})
+              ((base/require-bearer-token!
+                (fn [req] {:status 200}) #{"secrettoken"})
                {:headers {"authorization" "Bearer wrongtoken"}})))
       "should only return matching token")
 
   (is (= 401 (:status
-              ((require-bearer-token! (fn [req] {:status 200}) #{"secrettoken"})
+              ((base/require-bearer-token!
+                (fn [req] {:status 200}) #{"secrettoken"})
                {:headers {}}))) "should not set if no token present"))
 
 (deftest require-user-session
   (is (= 200 (:status
-              ((require-user-session! (fn [req] {:status 200}) #{"secrettoken"})
+              ((base/require-user-session!
+                (fn [req] {:status 200}) #{"secrettoken"})
                {:session {:access_token "secrettoken"}}))) "allow from session")
 
-  (let [response ((require-user-session! (fn [req] {:status 200})
-                                         #{"secrettoken"})
+  (let [response ((base/require-user-session!
+                   (fn [req] {:status 200}) #{"secrettoken"})
                   {:headers {"accept" "text/html"}
                    :query-string "test=123"
                    :uri "/protected"})]
@@ -108,96 +116,98 @@
         "set return-to"))
 
   (is (= 403 (:status
-              ((require-user-session! (fn [req] {:status 200}) #{"secrettoken"})
+              ((base/require-user-session!
+                (fn [req] {:status 200}) #{"secrettoken"})
                {:headers {"authorization" "Bearer secrettoken"}})))
       "Disallow from auth header")
   (is (= 403 (:status
-              ((require-user-session! (fn [req] {:status 200}) #{"secrettoken"})
+              ((base/require-user-session!
+                (fn [req] {:status 200}) #{"secrettoken"})
                {:cookies {"access_token" {:value "secrettoken"}}})))
       "Disallow from cookies")
   (is (= 403 (:status
-              ((require-user-session! (fn [req] {:status 200}) #{"secrettoken"})
+              ((base/require-user-session!
+                (fn [req] {:status 200}) #{"secrettoken"})
                {:params {:access_token "secrettoken"}})))
       "Disallow from params"))
 
 (deftest request-is-html
-  (is (not (is-html? {})))
-  (is (not (is-html? {:headers {"accept" "*/*"}})))
-  (is (not (is-html? {:headers {"accept" "application/json"}})))
-  (is (is-html? {:headers {"accept" "text/html"}}))
-  (is (is-html? {:headers {"accept" "application/xhtml+xml"}}))
-  (is (is-html?
+  (is (not (base/is-html? {})))
+  (is (not (base/is-html? {:headers {"accept" "*/*"}})))
+  (is (not (base/is-html? {:headers {"accept" "application/json"}})))
+  (is (base/is-html? {:headers {"accept" "text/html"}}))
+  (is (base/is-html? {:headers {"accept" "application/xhtml+xml"}}))
+  (is (base/is-html?
        {:headers
         {"accept"
          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}})))
 
 (deftest request-is-form
-  (is (not (is-form? {})))
-  (is (not (is-form? {:content-type "application/json"
+  (is (not (base/is-form? {})))
+  (is (not (base/is-form? {:content-type "application/json"
+                           :access-token "abcde"
+                           :session {:access_token "abcde"}})))
+  (is (not (base/is-form? {:content-type "application/xml"
+                           :access-token "abcde"
+                           :session {:access_token "abcde"}})))
+  (is (base/is-form? {:content-type "application/x-www-form-urlencoded"
                       :access-token "abcde"
-                      :session {:access_token "abcde"}})))
-  (is (not (is-form? {:content-type "application/xml"
+                      :session {:access_token "abcde"}}))
+  (is (base/is-form? {:content-type "multipart/form-data"
                       :access-token "abcde"
-                      :session {:access_token "abcde"}})))
-  (is (is-form? {:content-type "application/x-www-form-urlencoded"
-                 :access-token "abcde"
-                 :session {:access_token "abcde"}}))
-  (is (is-form? {:content-type "multipart/form-data"
-                 :access-token "abcde"
-                 :session {:access_token "abcde"}}))
-  (is (not (is-form? {:content-type "application/json"})))
-  (is (not (is-form? {:content-type "application/xml"})))
-  (is (is-form? {:content-type "application/x-www-form-urlencoded"}))
-  (is (is-form? {:content-type "multipart/form-data"}))
-  (is (not (is-form? {:content-type "application/json"
-                      :access-token "abcde"})))
-  (is (not (is-form? {:content-type "application/xml"
-                      :access-token "abcde"})))
-  (is (not (is-form? {:content-type "application/x-www-form-urlencoded"
-                      :access-token "abcde"})))
-  (is (not (is-form? {:content-type "multipart/form-data"
-                      :access-token "abcde"}))))
-
+                      :session {:access_token "abcde"}}))
+  (is (not (base/is-form? {:content-type "application/json"})))
+  (is (not (base/is-form? {:content-type "application/xml"})))
+  (is (base/is-form? {:content-type "application/x-www-form-urlencoded"}))
+  (is (base/is-form? {:content-type "multipart/form-data"}))
+  (is (not (base/is-form? {:content-type "application/json"
+                           :access-token "abcde"})))
+  (is (not (base/is-form? {:content-type "application/xml"
+                           :access-token "abcde"})))
+  (is (not (base/is-form? {:content-type "application/x-www-form-urlencoded"
+                           :access-token "abcde"})))
+  (is (not (base/is-form? {:content-type "multipart/form-data"
+                           :access-token "abcde"}))))
 
 (deftest request-if-html
-  (is (not (if-html {} true false)))
-  (is (not (if-html {:headers {"accept" "*/*"}} true false)))
-  (is (not (if-html {:headers {"accept" "application/json"}} true false)))
-  (is (if-html {:headers {"accept" "text/html"}} true false))
-  (is (if-html {:headers {"accept" "application/xhtml+xml"}} true false))
-  (is (if-html
+  (is (not (base/if-html {} true false)))
+  (is (not (base/if-html {:headers {"accept" "*/*"}} true false)))
+  (is (not (base/if-html {:headers {"accept" "application/json"}} true false)))
+  (is (base/if-html {:headers {"accept" "text/html"}} true false))
+  (is (base/if-html {:headers {"accept" "application/xhtml+xml"}} true false))
+  (is (base/if-html
        {:headers
         {"accept"
          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}}
        true false)))
 
 (deftest request-if-form
-  (is (not (if-form {} true false)))
-  (is (not (if-form {:content-type "application/json"} true false)))
-  (is (not (if-form {:content-type "application/xml"} true false)))
-  (is (if-form {:content-type "application/x-www-form-urlencoded"
-                :access-token "abcde"
-                :session {:access_token "abcde"}}
-               true false))
-  (is (if-form {:content-type "multipart/form-data"
-                :access-token "abcde"
-                :session {:access_token "abcde"}}
-               true false)))
+  (is (not (base/if-form {} true false)))
+  (is (not (base/if-form {:content-type "application/json"} true false)))
+  (is (not (base/if-form {:content-type "application/xml"} true false)))
+  (is (base/if-form {:content-type "application/x-www-form-urlencoded"
+                     :access-token "abcde"
+                     :session {:access_token "abcde"}}
+                    true false))
+  (is (base/if-form {:content-type "multipart/form-data"
+                     :access-token "abcde"
+                     :session {:access_token "abcde"}}
+                    true false)))
 
 (deftest csrf-token-extraction
-  (is (nil? (csrf-token {})))
-  (is (= "token" (csrf-token {:session {:csrf-token "token"}})))
-  (is (= "token" (csrf-token {:csrf-token "token"}))))
+  (is (nil? (base/csrf-token {})))
+  (is (= "token" (base/csrf-token {:session {:csrf-token "token"}})))
+  (is (= "token" (base/csrf-token {:csrf-token "token"}))))
 
 (deftest csrf-is-added-to-session
   ;; Should add a csrf-token entry to request if none is in session
-  (is (not (nil? (:csrf-token (with-csrf-token {})))))
+  (is (not (nil? (:csrf-token (base/with-csrf-token {})))))
   ;; should not add to request if one is already in request
-  (is (nil? (:csrf-token (with-csrf-token
+  (is (nil? (:csrf-token (base/with-csrf-token
                            {:session {:csrf-token "existing"}})))))
 
 (deftest protects-against-csrf
-  (let [handler (csrf-protect! (fn [req] req ))]
+  (let [handler (base/csrf-protect! (fn [req] req ))]
     (is (not (nil?
               (:csrf-token
                (:session
@@ -212,7 +222,7 @@
              (handler {:request-method :get
                        :session {:csrf-token "existing"}}))))))
 
-  (let [handler (csrf-protect! (fn [req] {:status 200}))]
+  (let [handler (base/csrf-protect! (fn [req] {:status 200}))]
     (is (= 403 (:status
                 (handler {:request-method :post
                           :content-type "application/x-www-form-urlencoded"
@@ -262,5 +272,5 @@
                 (handler {:request-method :post
                           :content-type "application/x-www-form-urlencoded"
                           :access-token "abcde"
-                          :session {csrf-token "secrettoken"
+                          :session {base/csrf-token "secrettoken"
                                     :access_token "abcde"}}))))))

--- a/test/clauth/test/middleware.clj
+++ b/test/clauth/test/middleware.clj
@@ -207,7 +207,7 @@
                            {:session {:csrf-token "existing"}})))))
 
 (deftest protects-against-csrf
-  (let [handler (base/csrf-protect! (fn [req] req ))]
+  (let [handler (base/csrf-protect! (fn [req] req))]
     (is (not (nil?
               (:csrf-token
                (:session

--- a/test/clauth/test/middleware.clj
+++ b/test/clauth/test/middleware.clj
@@ -2,223 +2,265 @@
   (:use [clauth.middleware]
         [clojure.test]))
 
-   (deftest bearer-token-from-header
-     
-     ;; authorization success adds oauth-token on request map
-     (is (= "secrettoken" (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {:headers {"authorization" "Bearer secrettoken"}}))) "find matching token")
+(deftest bearer-token-from-header
+  ;; authorization success adds oauth-token on request map
+  (is (= "secrettoken" (:access-token
+                        ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+                         {:headers {"authorization" "Bearer secrettoken"}})))
+      "find matching token")
 
-     (is (nil? (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {:headers {"authorization" "Bearer wrongtoken"}}))) "should only return matching token")
+  (is (nil? (:access-token
+             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+              {:headers {"authorization" "Bearer wrongtoken"}})))
+      "should only return matching token")
 
-      (is (nil? (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {:headers {}}))) "should not set if no token present"))
+  (is (nil? (:access-token
+             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+              {:headers {}}))) "should not set if no token present"))
+
+(deftest bearer-token-from-params
+  ;; authorization success adds oauth-token on request map
+  (is (= "secrettoken" (:access-token
+                        ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+                         {:params {:access_token "secrettoken"}})))
+      "find matching token")
+
+  (is (nil? (:access-token
+             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+              { :params {:access_token "wrongtoken"}})))
+      "should only return matching token")
+
+  (is (nil? (:access-token
+             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+              {}))) "should not set if no token present"))
+
+(deftest bearer-token-from-cookies
+  ;; authorization success adds oauth-token on request map
+  (is (= "secrettoken" (:access-token
+                        ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+                         {:cookies {"access_token" { :value "secrettoken"}}})))
+      "find matching token")
+
+  (is (nil? (:access-token
+             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+              {:cookies {"access_token" { :value "wrongtoken"}}})))
+      "should only return matching token")
+
+  (is (nil? (:access-token
+             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+              {}))) "should not set if no token present"))
+
+(deftest bearer-token-from-session
+  ;; authorization success adds oauth-token on request map
+  (is (= "secrettoken" (:access-token
+                        ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+                         {:session {:access_token "secrettoken"}})))
+      "find matching token")
+
+  (is (nil? (:access-token
+             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+              {:session {:access_token "wrongtoken"}})))
+      "should only return matching token")
+
+  (is (nil? (:access-token
+             ((wrap-bearer-token (fn [req] req) #{"secrettoken"})
+              {}))) "should not set if no token present"))
+
+(deftest require-token
+  ;; authorization success adds oauth-token on request map
+  (is (= 200 (:status
+              ((require-bearer-token! (fn [req] {:status 200}) #{"secrettoken"})
+               {:headers {"authorization" "Bearer secrettoken"}})))
+      "find matching token")
+
+  (let [response ((require-bearer-token! (fn [req] {:status 200})
+                                         #{"secrettoken"})
+                  {:headers {"accept" "text/html"}
+                   :query-string "test=123"
+                   :uri "/protected"})]
+    (is (= 302 (:status response)) "redirect")
+    (is (= "/login" ((:headers response) "Location")) "to login")
+    (is (= "/protected?test=123" ((:session response) :return-to))
+        "set return-to"))
+
+  (is (= 401 (:status
+              ((require-bearer-token! (fn [req] {:status 200}) #{"secrettoken"})
+               {:headers {"authorization" "Bearer wrongtoken"}})))
+      "should only return matching token")
+
+  (is (= 401 (:status
+              ((require-bearer-token! (fn [req] {:status 200}) #{"secrettoken"})
+               {:headers {}}))) "should not set if no token present"))
+
+(deftest require-user-session
+  (is (= 200 (:status
+              ((require-user-session! (fn [req] {:status 200}) #{"secrettoken"})
+               {:session {:access_token "secrettoken"}}))) "allow from session")
+
+  (let [response ((require-user-session! (fn [req] {:status 200})
+                                         #{"secrettoken"})
+                  {:headers {"accept" "text/html"}
+                   :query-string "test=123"
+                   :uri "/protected"})]
+    (is (= 302 (:status response)) "redirect")
+    (is (= "/login" ((:headers response) "Location")) "to login")
+    (is (= "/protected?test=123" ((:session response) :return-to))
+        "set return-to"))
+
+  (is (= 403 (:status
+              ((require-user-session! (fn [req] {:status 200}) #{"secrettoken"})
+               {:headers {"authorization" "Bearer secrettoken"}})))
+      "Disallow from auth header")
+  (is (= 403 (:status
+              ((require-user-session! (fn [req] {:status 200}) #{"secrettoken"})
+               {:cookies {"access_token" {:value "secrettoken"}}})))
+      "Disallow from cookies")
+  (is (= 403 (:status
+              ((require-user-session! (fn [req] {:status 200}) #{"secrettoken"})
+               {:params {:access_token "secrettoken"}})))
+      "Disallow from params"))
+
+(deftest request-is-html
+  (is (not (is-html? {})))
+  (is (not (is-html? {:headers {"accept" "*/*"}})))
+  (is (not (is-html? {:headers {"accept" "application/json"}})))
+  (is (is-html? {:headers {"accept" "text/html"}}))
+  (is (is-html? {:headers {"accept" "application/xhtml+xml"}}))
+  (is (is-html?
+       {:headers
+        {"accept"
+         "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}})))
+
+(deftest request-is-form
+  (is (not (is-form? {})))
+  (is (not (is-form? {:content-type "application/json"
+                      :access-token "abcde"
+                      :session {:access_token "abcde"}})))
+  (is (not (is-form? {:content-type "application/xml"
+                      :access-token "abcde"
+                      :session {:access_token "abcde"}})))
+  (is (is-form? {:content-type "application/x-www-form-urlencoded"
+                 :access-token "abcde"
+                 :session {:access_token "abcde"}}))
+  (is (is-form? {:content-type "multipart/form-data"
+                 :access-token "abcde"
+                 :session {:access_token "abcde"}}))
+  (is (not (is-form? {:content-type "application/json"})))
+  (is (not (is-form? {:content-type "application/xml"})))
+  (is (is-form? {:content-type "application/x-www-form-urlencoded"}))
+  (is (is-form? {:content-type "multipart/form-data"}))
+  (is (not (is-form? {:content-type "application/json"
+                      :access-token "abcde"})))
+  (is (not (is-form? {:content-type "application/xml"
+                      :access-token "abcde"})))
+  (is (not (is-form? {:content-type "application/x-www-form-urlencoded"
+                      :access-token "abcde"})))
+  (is (not (is-form? {:content-type "multipart/form-data"
+                      :access-token "abcde"}))))
 
 
+(deftest request-if-html
+  (is (not (if-html {} true false)))
+  (is (not (if-html {:headers {"accept" "*/*"}} true false)))
+  (is (not (if-html {:headers {"accept" "application/json"}} true false)))
+  (is (if-html {:headers {"accept" "text/html"}} true false))
+  (is (if-html {:headers {"accept" "application/xhtml+xml"}} true false))
+  (is (if-html
+       {:headers
+        {"accept"
+         "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}}
+       true false)))
 
-   (deftest bearer-token-from-params
-     
-     ;; authorization success adds oauth-token on request map
-     (is (= "secrettoken" (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {:params {:access_token "secrettoken"}}))) "find matching token")
+(deftest request-if-form
+  (is (not (if-form {} true false)))
+  (is (not (if-form {:content-type "application/json"} true false)))
+  (is (not (if-form {:content-type "application/xml"} true false)))
+  (is (if-form {:content-type "application/x-www-form-urlencoded"
+                :access-token "abcde"
+                :session {:access_token "abcde"}}
+               true false))
+  (is (if-form {:content-type "multipart/form-data"
+                :access-token "abcde"
+                :session {:access_token "abcde"}}
+               true false)))
 
-     (is (nil? (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        { :params {:access_token "wrongtoken"}}))) "should only return matching token")
+(deftest csrf-token-extraction
+  (is (nil? (csrf-token {})))
+  (is (= "token" (csrf-token {:session {:csrf-token "token"}})))
+  (is (= "token" (csrf-token {:csrf-token "token"}))))
 
-      (is (nil? (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {}))) "should not set if no token present"))
+(deftest csrf-is-added-to-session
+  ;; Should add a csrf-token entry to request if none is in session
+  (is (not (nil? (:csrf-token (with-csrf-token {})))))
+  ;; should not add to request if one is already in request
+  (is (nil? (:csrf-token (with-csrf-token
+                           {:session {:csrf-token "existing"}})))))
 
-   (deftest bearer-token-from-cookies
-     
-     ;; authorization success adds oauth-token on request map
-     (is (= "secrettoken" (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {:cookies {"access_token" { :value "secrettoken"}}}))) "find matching token")
+(deftest protects-against-csrf
+  (let [handler (csrf-protect! (fn [req] req ))]
+    (is (not (nil?
+              (:csrf-token
+               (:session
+                (handler {:request-method :get
+                          :headers { "accept" "text/html"}
+                          :access-token "abcde"
+                          :session {:access_token "abcde"}}))))))
 
-     (is (nil? (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {:cookies {"access_token" { :value "wrongtoken"}}}))) "should only return matching token")
+    (is (= "existing"
+           (:csrf-token
+            (:session
+             (handler {:request-method :get
+                       :session {:csrf-token "existing"}}))))))
 
-      (is (nil? (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {}))) "should not set if no token present"))
+  (let [handler (csrf-protect! (fn [req] {:status 200}))]
+    (is (= 403 (:status
+                (handler {:request-method :post
+                          :content-type "application/x-www-form-urlencoded"
+                          :access-token "abcde"
+                          :session {:access_token "abcde"}})))
+        "should fail for html post without token")
 
-   (deftest bearer-token-from-session
-     
-     ;; authorization success adds oauth-token on request map
-     (is (= "secrettoken" (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        { :session { :access_token "secrettoken" }}))) "find matching token")
+    (is (= 200 (:status
+                (handler
+                 {:request-method :post
+                  :content-type "application/json"
+                  :access-token "abcde"
+                  :session {:access_token "abcde"}})))
+        "should allow non html")
 
-     (is (nil? (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        { :session { :access_token "wrongtoken" }}))) "should only return matching token")
+    (is (= 200 (:status
+                (handler {:request-method :get
+                          :headers {"accept" "text/html"}
+                          :access-token "abcde"
+                          :session {:access_token "abcde"}}))))
 
-      (is (nil? (:access-token
-                     ((wrap-bearer-token (fn [req] req)
-                                                 #{"secrettoken"})
-                        {}))) "should not set if no token present"))
+    (is (not (nil? (:csrf-token
+                    (:session
+                     (handler {:request-method :get
+                               :headers {"accept" "text/html"}}))))))
 
-   (deftest require-token
-     
-     ;; authorization success adds oauth-token on request map
-     (is (= 200 (:status
-                     ((require-bearer-token! (fn [req] {:status 200} )
-                                                 #{"secrettoken"})
-                        {:headers {"authorization" "Bearer secrettoken"}}))) "find matching token")
+    (let [response (handler {:request-method :get
+                             :headers {"accept" "text/html"}
+                             :session {:csrf-token "existing"}})]
+      (is (nil? (:session response))))
 
-     (let [response ((require-bearer-token! (fn [req] {:status 200} )
-                                                 #{"secrettoken"})
-                         { :headers { "accept" "text/html" } :query-string "test=123" :uri "/protected" })]
-         (is (= 302 (:status response)) "redirect")
-         (is (= "/login" ((:headers response) "Location")) "to login")
-         (is (= "/protected?test=123" ((:session response) :return-to)) "set return-to"))
-
-     (is (= 401 (:status
-                     ((require-bearer-token! (fn [req] {:status 200})
-                                                 #{"secrettoken"})
-                        {:headers {"authorization" "Bearer wrongtoken"}}))) "should only return matching token")
-
-      (is (= 401 (:status
-                     ((require-bearer-token! (fn [req] {:status 200})
-                                                 #{"secrettoken"})
-                        {:headers {}}))) "should not set if no token present"))
-
-   (deftest require-user-session
-     
-     (is (= 200 (:status
-                     ((require-user-session! (fn [req] {:status 200} )
-                                                 #{"secrettoken"})
-                         { :session { :access_token "secrettoken" }}))) "allow from session")
-
-     (let [response ((require-user-session! (fn [req] {:status 200} )
-                                                 #{"secrettoken"})
-                         { :headers { "accept" "text/html" } :query-string "test=123" :uri "/protected" })]
-         (is (= 302 (:status response)) "redirect")
-         (is (= "/login" ((:headers response) "Location")) "to login")
-         (is (= "/protected?test=123" ((:session response) :return-to)) "set return-to"))
-
-     (is (= 403 (:status
-                     ((require-user-session! (fn [req] {:status 200} )
-                                                 #{"secrettoken"})
-                        {:headers {"authorization" "Bearer secrettoken"}}))) "Disallow from auth header")
-     (is (= 403 (:status
-                 ((require-user-session! (fn [req] {:status 200} )
-                                             #{"secrettoken"})
-                    {:cookies {"access_token" { :value "secrettoken"}}}))) "Disallow from cookies")
-     (is (= 403 (:status
-                     ((require-user-session! (fn [req] {:status 200} )
-                                                 #{"secrettoken"})
-                        {:params {:access_token "secrettoken"}}))) "Disallow from params"))
-
-
-
-    (deftest request-is-html
-        (is (not (is-html? {})))
-        (is (not (is-html? {:headers {"accept" "*/*"}})))
-        (is (not (is-html? {:headers {"accept" "application/json"}})))
-        (is (is-html? {:headers {"accept" "text/html"}}))
-        (is (is-html? {:headers {"accept" "application/xhtml+xml"}}))
-        (is (is-html? {:headers {"accept" "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}})))
-
-    (deftest request-is-form
-        (is (not (is-form? {})))
-        (is (not (is-form? {:content-type "application/json" :access-token "abcde" :session {:access_token "abcde"}})))
-        (is (not (is-form? {:content-type "application/xml" :access-token "abcde" :session {:access_token "abcde"}})))
-        (is (is-form? {:content-type "application/x-www-form-urlencoded" :access-token "abcde" :session {:access_token "abcde"}}))
-        (is (is-form? {:content-type "multipart/form-data" :access-token "abcde" :session {:access_token "abcde"}}))
-
-        (is (not (is-form? {:content-type "application/json" })))
-        (is (not (is-form? {:content-type "application/xml" })))
-        (is (is-form? {:content-type "application/x-www-form-urlencoded" }))
-        (is (is-form? {:content-type "multipart/form-data" }))
-
-        (is (not (is-form? {:content-type "application/json" :access-token "abcde" })))
-        (is (not (is-form? {:content-type "application/xml" :access-token "abcde" })))
-        (is (not (is-form? {:content-type "application/x-www-form-urlencoded" :access-token "abcde" })))
-        (is (not (is-form? {:content-type "multipart/form-data" :access-token "abcde" }))))
-        
-
-    (deftest request-if-html
-        (is (not (if-html {} true false)))
-        (is (not (if-html {:headers {"accept" "*/*"}} true false)))
-        (is (not (if-html {:headers {"accept" "application/json"}} true false)))
-        (is (if-html {:headers {"accept" "text/html"}} true false))
-        (is (if-html {:headers {"accept" "application/xhtml+xml"}} true false))
-        (is (if-html {:headers {"accept" "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}} true false)))
-
-    (deftest request-if-form
-        (is (not (if-form {} true false)))
-        (is (not (if-form {:content-type "application/json"} true false)))
-        (is (not (if-form {:content-type "application/xml"} true false)))
-        (is (if-form {:content-type "application/x-www-form-urlencoded" :access-token "abcde" :session {:access_token "abcde"}} true false))
-        (is (if-form {:content-type "multipart/form-data" :access-token "abcde" :session {:access_token "abcde"}} true false)))
-
-    (deftest csrf-token-extraction
-        (is (nil? (csrf-token {})))
-        (is (= "token" (csrf-token { :session { :csrf-token "token" }})))
-        (is (= "token" (csrf-token { :csrf-token "token" }))))
-
-    (deftest csrf-is-added-to-session
-        ;; Should add a csrf-token entry to request if none is in session
-        (is (not (nil? (:csrf-token (with-csrf-token {}))))) 
-        ;; should not add to request if one is already in request
-        (is (nil? (:csrf-token (with-csrf-token { :session {:csrf-token "existing"}}))))) 
-
-    (deftest protects-against-csrf
-        (let [handler (csrf-protect! (fn [req] req ))]
-            (is (not (nil? (:csrf-token (:session (handler { :request-method :get :headers { "accept" "text/html" } :access-token "abcde" :session {:access_token "abcde"}} ))))))
-
-            (is (= "existing" (:csrf-token (:session (handler { :request-method :get :session {:csrf-token "existing"}}))))))
-
-        (let [handler (csrf-protect! (fn [req] {:status 200 } ))]
-            (is (= 403 (:status
-                        (handler { :request-method :post :content-type "application/x-www-form-urlencoded" :access-token "abcde" :session {:access_token "abcde"}}))) "should fail for html post without token")
-            
-            (is (= 200 (:status
-                        (handler { :request-method :post :content-type "application/json" :access-token "abcde" :session {:access_token "abcde"}}))) "should allow non html")
-
-            (is (= 200 (:status
-                        (handler { :request-method :get :headers { "accept" "text/html" } :access-token "abcde" :session {:access_token "abcde"} }))))
-
-            (is (not (nil? (:csrf-token (:session
-                        (handler { :request-method :get :headers { "accept" "text/html" }}))))))
-
-            (let [response (handler { :request-method :get :headers { "accept" "text/html" } :session {:csrf-token "existing"}})]
-                (is (nil? (:session response ))))
-
-            (is (= 200 (:status
-                        (handler {  :request-method :post 
-                                    :content-type "application/x-www-form-urlencoded"
-                                    :access-token "abcde"
-                                    :session {:csrf-token "secrettoken" :access_token "abcde"} 
-                                    :params  {:csrf-token "secrettoken"} }))))
-            (is (= 403 (:status
-                        (handler {  :request-method :post 
-                                    :content-type "application/x-www-form-urlencoded"
-                                    :access-token "abcde"
-                                    :session {:csrf-token "secrettoken" :access_token "abcde"} 
-                                    :params  {:csrf-token "badtoken"} }))))
-            (is (= 403 (:status
-                        (handler {  :request-method :post 
-                                    :content-type "application/x-www-form-urlencoded"
-                                    :access-token "abcde"
-                                    :session {csrf-token "secrettoken" :access_token "abcde"}}))))
-            ))
+    (is (= 200 (:status
+                (handler {:request-method :post
+                          :content-type "application/x-www-form-urlencoded"
+                          :access-token "abcde"
+                          :session {:csrf-token "secrettoken"
+                                    :access_token "abcde"}
+                          :params  {:csrf-token "secrettoken"}}))))
+    (is (= 403 (:status
+                (handler {:request-method :post
+                          :content-type "application/x-www-form-urlencoded"
+                          :access-token "abcde"
+                          :session {:csrf-token "secrettoken"
+                                    :access_token "abcde"}
+                          :params  {:csrf-token "badtoken"}}))))
+    (is (= 403 (:status
+                (handler {:request-method :post
+                          :content-type "application/x-www-form-urlencoded"
+                          :access-token "abcde"
+                          :session {csrf-token "secrettoken"
+                                    :access_token "abcde"}}))))))

--- a/test/clauth/test/store.clj
+++ b/test/clauth/test/store.clj
@@ -1,25 +1,19 @@
 (ns clauth.test.store
   (:use [clauth.store]
         [clojure.test]))
-  
 
-
-  (deftest memory-store-implementaiton
-    (let [st (create-memory-store)]
-      (is (= 0 (count (entries st))))
-      (is (= [] (entries st)))
-      (is (nil? (fetch st "item")))
-
-      (let [item (store! st :key {:key  "item" :hello "world"})]
-        (is (= 1 (count (entries st))))
-        (is (= item (fetch st "item")))
-        (is (= [item] (entries st)))
-        (let [_ (revoke! st "item")]
-          (is (nil? (fetch st "item"))))
-        (do
-          (reset-store! st)
+(deftest memory-store-implementaiton
+  (let [st (create-memory-store)]
+    (is (= 0 (count (entries st))))
+    (is (= [] (entries st)))
+    (is (nil? (fetch st "item")))
+    (let [item (store! st :key {:key  "item" :hello "world"})]
+      (is (= 1 (count (entries st))))
+      (is (= item (fetch st "item")))
+      (is (= [item] (entries st)))
+      (let [_ (revoke! st "item")]
+        (is (nil? (fetch st "item"))))
+      (do (reset-store! st)
           (is (= 0 (count (entries st))))
           (is (= [] (entries st)))
           (is (nil? (fetch st "item")))))))
-
- 

--- a/test/clauth/test/store.clj
+++ b/test/clauth/test/store.clj
@@ -1,19 +1,19 @@
 (ns clauth.test.store
-  (:use [clauth.store]
-        [clojure.test]))
+  (:require [clojure.test :refer :all]
+            [clauth.store :as base]))
 
 (deftest memory-store-implementaiton
-  (let [st (create-memory-store)]
-    (is (= 0 (count (entries st))))
-    (is (= [] (entries st)))
-    (is (nil? (fetch st "item")))
-    (let [item (store! st :key {:key  "item" :hello "world"})]
-      (is (= 1 (count (entries st))))
-      (is (= item (fetch st "item")))
-      (is (= [item] (entries st)))
-      (let [_ (revoke! st "item")]
-        (is (nil? (fetch st "item"))))
-      (do (reset-store! st)
-          (is (= 0 (count (entries st))))
-          (is (= [] (entries st)))
-          (is (nil? (fetch st "item")))))))
+  (let [st (base/create-memory-store)]
+    (is (= 0 (count (base/entries st))))
+    (is (= [] (base/entries st)))
+    (is (nil? (base/fetch st "item")))
+    (let [item (base/store! st :key {:key  "item" :hello "world"})]
+      (is (= 1 (count (base/entries st))))
+      (is (= item (base/fetch st "item")))
+      (is (= [item] (base/entries st)))
+      (let [_ (base/revoke! st "item")]
+        (is (nil? (base/fetch st "item"))))
+      (do (base/reset-store! st)
+          (is (= 0 (count (base/entries st))))
+          (is (= [] (base/entries st)))
+          (is (nil? (base/fetch st "item")))))))

--- a/test/clauth/test/store/redis.clj
+++ b/test/clauth/test/store/redis.clj
@@ -7,86 +7,71 @@
         [clauth.store.redis]
         [clojure.test]))
 
-
-  (deftest redis-store-implementaiton
-    (redis/with-server
-     {:host "127.0.0.1"
-      :port 6379
-      :db 15
-     }
-
+(deftest redis-store-implementaiton
+  (redis/with-server
+    {:host "127.0.0.1"
+     :port 6379
+     :db 15}
     (let [st (create-redis-store "testing")]
       (reset-store! st)
       (is (= 0 (count (entries st))))
       (is (= [] (entries st)))
       (is (nil? (fetch st "item")))
-
       (let [item (store! st :key {:key  "item" :hello "world"})]
         (is (= 1 (count (entries st))))
         (is (= item (fetch st "item")))
         (is (= [item] (entries st)))
         (let [_ (revoke! st "item")]
           (is (nil? (fetch st "item"))))
+        (do (reset-store! st)
+            (is (= 0 (count (entries st))))
+            (is (= [] (entries st)))
+            (is (nil? (fetch st "item"))))))))
 
-        (do
-          (reset-store! st)
-          (is (= 0 (count (entries st))))
-          (is (= [] (entries st)))
-          (is (nil? (fetch st "item"))))))))
 
- 
-  (deftest token-store-implementation
-    (redis/with-server
-     {:host "127.0.0.1"
-      :port 6379
-      :db 15
-     }
-     (reset! token-store (create-redis-store "tokens"))
-     (reset-token-store!)
-     (is (= 0 (count (tokens))) "starts out empty")
-     (let 
+(deftest token-store-implementation
+  (redis/with-server
+    {:host "127.0.0.1"
+     :port 6379
+     :db 15}
+    (reset! token-store (create-redis-store "tokens"))
+    (reset-token-store!)
+    (is (= 0 (count (tokens))) "starts out empty")
+    (let
         [record (oauth-token "my-client" "my-user")]
-        (is (nil? (fetch-token (:token record))))
-        (do
-          (store-token record)
+      (is (nil? (fetch-token (:token record))))
+      (do (store-token record)
           (is (= record (fetch-token (:token record))))
           (is (= 1 (count (tokens))) "added one"))))
-     (reset! token-store (create-memory-store)))
+  (reset! token-store (create-memory-store)))
 
-  (deftest client-store-implementation
-    (redis/with-server
-     {:host "127.0.0.1"
-      :port 6379
-      :db 15
-     }
-     (reset! client-store (create-redis-store "clients"))
-     (reset-client-store!)
-     (is (= 0 (count (clients))) "starts out empty")
-     (let 
-        [ record (client-app)]
-        (is (nil? (fetch-client (:client-id record))))
-        (do
-          (store-client record)
+(deftest client-store-implementation
+  (redis/with-server
+    {:host "127.0.0.1"
+     :port 6379
+     :db 15}
+    (reset! client-store (create-redis-store "clients"))
+    (reset-client-store!)
+    (is (= 0 (count (clients))) "starts out empty")
+    (let [record (client-app)]
+      (is (nil? (fetch-client (:client-id record))))
+      (do (store-client record)
           (is (= record (fetch-client (:client-id record))))
           (is (= 1 (count (clients))) "added one"))))
-      (reset! client-store (create-memory-store)))
+  (reset! client-store (create-memory-store)))
 
 
-   (deftest user-store-implementation
-    (redis/with-server
-     {:host "127.0.0.1"
-      :port 6379
-      :db 15
-     }
-     (reset! user-store (create-redis-store "users"))
-     (reset-user-store!)
-     (is (= 0 (count (users))) "starts out empty")
-     (let 
-        [ record (new-user "john@example.com" "password")]
-        (is (nil? (fetch-user "john@example.com")))
-        (do
-          (store-user record)
+(deftest user-store-implementation
+  (redis/with-server
+    {:host "127.0.0.1"
+     :port 6379
+     :db 15}
+    (reset! user-store (create-redis-store "users"))
+    (reset-user-store!)
+    (is (= 0 (count (users))) "starts out empty")
+    (let [record (new-user "john@example.com" "password")]
+      (is (nil? (fetch-user "john@example.com")))
+      (do (store-user record)
           (is (= record (fetch-user "john@example.com")))
           (is (= 1 (count (users))) "added one"))))
-      (reset! user-store (create-memory-store)))
-
+  (reset! user-store (create-memory-store)))

--- a/test/clauth/test/token.clj
+++ b/test/clauth/test/token.clj
@@ -1,39 +1,39 @@
 (ns clauth.test.token
-  (:use [clauth.token]
-        [clojure.test])
-  (:require [clj-time.core :as time]))
+  (:require [clojure.test :refer :all]
+            [clauth.token :as base]
+            [clj-time.core :as time]))
 
 (deftest token-records
-  (let [record (oauth-token "my-client" "user")]
-    (is (= "my-client" ( :client record )) "should have client")
-    (is (= "user" ( :subject record )) "should have client")
-    (is (not (nil? (:token record  ))) "should include token field")
-    (is (is-valid? record) "should be valid by default")))
+  (let [record (base/oauth-token "my-client" "user")]
+    (is (= "my-client" (:client record)) "should have client")
+    (is (= "user" (:subject record)) "should have client")
+    (is (not (nil? (:token record))) "should include token field")
+    (is (base/is-valid? record) "should be valid by default")))
 
 (deftest token-creation
-  (reset-token-store!)
-  (is (= 0 (count (tokens))) "starts out empty")
-  (let [record (create-token "my-client" "my-user")]
-    (is (= "my-client" ( :client record )) "should have client")
-    (is (= "my-user" ( :subject record )) "should have subject")
-    (is (not (nil? (:token record ))) "should include token field")
-    (is (= 1 (count (tokens ))) "added one")
-    (is (= record (first (tokens ))) "added one")
-    (is (= record (find-valid-token (:token record))))))
+  (base/reset-token-store!)
+  (is (= 0 (count (base/tokens))) "starts out empty")
+  (let [record (base/create-token "my-client" "my-user")]
+    (is (= "my-client" (:client record)) "should have client")
+    (is (= "my-user" (:subject record)) "should have subject")
+    (is (not (nil? (:token record))) "should include token field")
+    (is (= 1 (count (base/tokens))) "added one")
+    (is (= record (first (base/tokens))) "added one")
+    (is (= record (base/find-valid-token (:token record))))))
 
 (deftest token-validity
-  (is (is-valid? {}) "by default it's valid")
-  (is (not (is-valid? nil)) "nil is always false")
-  (is (is-valid? {:expires (time/plus (time/now) (time/days 1))})
+  (is (base/is-valid? {}) "by default it's valid")
+  (is (not (base/is-valid? nil)) "nil is always false")
+  (is (base/is-valid? {:expires (time/plus (time/now) (time/days 1))})
       "valid if expiry date is in the future")
-  (is (not (is-valid? {:expires (time/date-time 2012 3 13)}))
+  (is (not (base/is-valid? {:expires (time/date-time 2012 3 13)}))
       "expires if past expiry date"))
 
 (deftest token-store-implementation
-  (reset-token-store!)
-  (is (= 0 (count (tokens))) "starts out empty")
-  (let [record (oauth-token "my-client" "my-user")]
-    (is (nil? (fetch-token (:token record))))
-    (do (store-token record)
-        (is (= record (fetch-token (:token record))))
-        (is (= 1 (count (tokens))) "added one"))))
+  (base/reset-token-store!)
+  (is (= 0 (count (base/tokens))) "starts out empty")
+  (let [record (base/oauth-token "my-client" "my-user")]
+    (is (nil? (base/fetch-token (:token record))))
+    (do (base/store-token record)
+        (is (= record (base/fetch-token (:token record))))
+        (is (= 1 (count (base/tokens))) "added one"))))

--- a/test/clauth/test/token.clj
+++ b/test/clauth/test/token.clj
@@ -3,40 +3,37 @@
         [clojure.test])
   (:require [clj-time.core :as time]))
 
-   (deftest token-records
-     (let 
-        [record (oauth-token "my-client" "user")]
-        (is (= "my-client" ( :client record )) "should have client")
-        (is (= "user" ( :subject record )) "should have client")
-        (is (not (nil? (:token record  ))) "should include token field")
-        (is (is-valid? record) "should be valid by default")))
+(deftest token-records
+  (let [record (oauth-token "my-client" "user")]
+    (is (= "my-client" ( :client record )) "should have client")
+    (is (= "user" ( :subject record )) "should have client")
+    (is (not (nil? (:token record  ))) "should include token field")
+    (is (is-valid? record) "should be valid by default")))
 
-   (deftest token-creation
-     (reset-token-store!)
-     (is (= 0 (count (tokens))) "starts out empty")
-     (let 
-        [record (create-token "my-client" "my-user")]
-        (is (= "my-client" ( :client record )) "should have client")
-        (is (= "my-user" ( :subject record )) "should have subject")
-        (is (not (nil? (:token record ))) "should include token field")
-        (is (= 1 (count (tokens ))) "added one")
-        (is (= record (first (tokens ))) "added one")
-        (is (= record (find-valid-token (:token record))))))
+(deftest token-creation
+  (reset-token-store!)
+  (is (= 0 (count (tokens))) "starts out empty")
+  (let [record (create-token "my-client" "my-user")]
+    (is (= "my-client" ( :client record )) "should have client")
+    (is (= "my-user" ( :subject record )) "should have subject")
+    (is (not (nil? (:token record ))) "should include token field")
+    (is (= 1 (count (tokens ))) "added one")
+    (is (= record (first (tokens ))) "added one")
+    (is (= record (find-valid-token (:token record))))))
 
-   (deftest token-validity
-      (is (is-valid? {}) "by default it's valid")
-      (is (not (is-valid? nil)) "nil is always false")
-      (is (is-valid? {:expires (time/plus (time/now) (time/days 1))}) "valid if expiry date is in the future")
-      (is (not (is-valid? {:expires (time/date-time 2012 3 13)})) "expires if past expiry date")
-    )
+(deftest token-validity
+  (is (is-valid? {}) "by default it's valid")
+  (is (not (is-valid? nil)) "nil is always false")
+  (is (is-valid? {:expires (time/plus (time/now) (time/days 1))})
+      "valid if expiry date is in the future")
+  (is (not (is-valid? {:expires (time/date-time 2012 3 13)}))
+      "expires if past expiry date"))
 
-   (deftest token-store-implementation
-     (reset-token-store!)
-     (is (= 0 (count (tokens))) "starts out empty")
-     (let 
-        [record (oauth-token "my-client" "my-user")]
-        (is (nil? (fetch-token (:token record))))
-        (do
-          (store-token record)
-          (is (= record (fetch-token (:token record))))
-          (is (= 1 (count (tokens))) "added one"))))
+(deftest token-store-implementation
+  (reset-token-store!)
+  (is (= 0 (count (tokens))) "starts out empty")
+  (let [record (oauth-token "my-client" "my-user")]
+    (is (nil? (fetch-token (:token record))))
+    (do (store-token record)
+        (is (= record (fetch-token (:token record))))
+        (is (= 1 (count (tokens))) "added one"))))

--- a/test/clauth/test/user.clj
+++ b/test/clauth/test/user.clj
@@ -1,27 +1,27 @@
 (ns clauth.test.user
-  (:use [clauth.user]
-        [clojure.test]))
+  (:require [clojure.test :refer :all]
+            [clauth.user :as base]))
 
 (deftest user-registration
-  (reset-user-store!)
-  (let [record (register-user "john@example.com" "password" "John Doe"
-                              "http://example.com")]
+  (base/reset-user-store!)
+  (let [record (base/register-user "john@example.com" "password" "John Doe"
+                                   "http://example.com")]
     (is (= "John Doe" (:name record)) "should add extra attributes to user")
-    (is (= 1 (count (users))) "added one")
-    (is (= record (first (users))) "added one")
-    (is (= record (authenticate-user "john@example.com" "password"))
+    (is (= 1 (count (base/users))) "added one")
+    (is (= record (first (base/users))) "added one")
+    (is (= record (base/authenticate-user "john@example.com" "password"))
         "should authenticate user")
-    (is (nil? (authenticate-user "john@example.com" "bad"))
+    (is (nil? (base/authenticate-user "john@example.com" "bad"))
         "should not authenticate user with wrong password")
-    (is (nil? (authenticate-user "idontexist" "bad"))
+    (is (nil? (base/authenticate-user "idontexist" "bad"))
         "should not authenticate user with wrong id")))
 
 (deftest user-store-implementation
-  (reset-user-store!)
-  (is (= 0 (count (users))) "starts out empty")
-  (let [record (new-user "john@example.com" "password")]
-    (is (nil? (fetch-user "john@example.com")))
+  (base/reset-user-store!)
+  (is (= 0 (count (base/users))) "starts out empty")
+  (let [record (base/new-user "john@example.com" "password")]
+    (is (nil? (base/fetch-user "john@example.com")))
     (do
-      (store-user record)
-      (is (= record (fetch-user "john@example.com")))
-      (is (= 1 (count (users))) "added one"))))
+      (base/store-user record)
+      (is (= record (base/fetch-user "john@example.com")))
+      (is (= 1 (count (base/users))) "added one"))))

--- a/test/clauth/test/user.clj
+++ b/test/clauth/test/user.clj
@@ -2,24 +2,26 @@
   (:use [clauth.user]
         [clojure.test]))
 
-   (deftest user-registration
-     (reset-user-store!)
-     (let 
-        [ record (register-user "john@example.com" "password" "John Doe" "http://example.com")]
-        (is (= "John Doe" (:name record )) "should add extra attributes to user")
-        (is (= 1 (count (users))) "added one")
-        (is (= record (first (users))) "added one")
-        (is (= record (authenticate-user "john@example.com" "password")) "should authenticate user")
-        (is (nil? (authenticate-user "john@example.com" "bad")) "should not authenticate user with wrong password")
-        (is (nil? (authenticate-user "idontexist" "bad")) "should not authenticate user with wrong id")))
+(deftest user-registration
+  (reset-user-store!)
+  (let [record (register-user "john@example.com" "password" "John Doe"
+                              "http://example.com")]
+    (is (= "John Doe" (:name record)) "should add extra attributes to user")
+    (is (= 1 (count (users))) "added one")
+    (is (= record (first (users))) "added one")
+    (is (= record (authenticate-user "john@example.com" "password"))
+        "should authenticate user")
+    (is (nil? (authenticate-user "john@example.com" "bad"))
+        "should not authenticate user with wrong password")
+    (is (nil? (authenticate-user "idontexist" "bad"))
+        "should not authenticate user with wrong id")))
 
-   (deftest user-store-implementation
-     (reset-user-store!)
-     (is (= 0 (count (users))) "starts out empty")
-     (let 
-        [ record (new-user "john@example.com" "password")]
-        (is (nil? (fetch-user "john@example.com")))
-        (do
-          (store-user record)
-          (is (= record (fetch-user "john@example.com")))
-          (is (= 1 (count (users))) "added one"))))
+(deftest user-store-implementation
+  (reset-user-store!)
+  (is (= 0 (count (users))) "starts out empty")
+  (let [record (new-user "john@example.com" "password")]
+    (is (nil? (fetch-user "john@example.com")))
+    (do
+      (store-user record)
+      (is (= record (fetch-user "john@example.com")))
+      (is (= 1 (count (users))) "added one"))))


### PR DESCRIPTION
Hi Pelle,

Apologies for seemingly large size of this pull request. It is actually quite a focused on a few minor, but I would consider important changes, which I list below.  These changes improve the adherence to best practices that are widely accepted in throughout the Clojure developer community.

I have some other more substantial ideas on how to improve clauth, but these changes that do not affect functionality seem to me to be prerequisite to making it easier to contribute these other changes, so I am delaying that until after we deal with these changes. 

Changes in this pull request:
1. Formatting of parentheses: in Clojure and the Lisp communities it is derrived from it is a solid convention that closing parentheses never go on a separate line like C brackets.
2. Expressions like "( a b c)" should instead be "(a b c)" both when being used as code and as data.  I fixed these whitespace anomalies as well as other non-syntactic whitespace that occurred in the files in random places.
3. 80-character limit: lines longer than 80 characters have been reformatted in reasonable ways.
4. Indentation: I fixed the irregularities of indentation and apply a more standard Clojure/Lisp indentation style. Because of this, the diff difficult to read, but adding the "?w=1" to ignore whitespace will help a lot in reading the diff. 
5. There is a debate over "use" vs. "require" (and many now consider "use" semi-deprecated by the 1.4 require :refer feature), but there is general consensus that a naked "use" referring all vars into the namespace makes code very difficult to understand, and I have personally found this to be the case in almost every place I have encountered it.  To me it seems there are still many instances in which referring vars by symbol name into a namespace makes sense.  For example in tests, I would tend to refer the test framework in wholesale, and when only a var named by a very obvious symbol is needed (such as is frequently the case in clauth.demo for example) I would refer in just that one var.  In these cases I believe the the explicit refer adds a lot of clarity to the code, just as do require :as aliases which I consider the best way to clarify the source of a var as long it does not clutter or get in the way.
