### PR TITLE
Added a revoke-token function to token.clj to expose this functionality ...

### DIFF
--- a/src/clauth/token.clj
+++ b/src/clauth/token.clj
@@ -67,6 +67,13 @@
   [t]
   (store/store! @token-store :token t))
 
+(defn revoke-token
+  "Revoke the given OAuth token, given either a token string or object."
+  [t]
+  (cond
+   (instance? java.lang.String t) (store/revoke! @token-store t)
+   :default (store/revoke! @token-store (:token t))))
+
 (defn tokens
   "Sequence of tokens"
   []

--- a/test/clauth/test/token.clj
+++ b/test/clauth/test/token.clj
@@ -36,4 +36,7 @@
     (is (nil? (base/fetch-token (:token record))))
     (do (base/store-token record)
         (is (= record (base/fetch-token (:token record))))
-        (is (= 1 (count (base/tokens))) "added one"))))
+        (is (= 1 (count (base/tokens))) "added one"))
+    (do (base/revoke-token record)
+        (is (= nil (base/fetch-token (:token record))))
+        (is (= 0 (count (base/tokens))) "revoked one"))))


### PR DESCRIPTION
... from the token store implementations. We need people to be able to log out using our API, and this seems the cleanest way to support that. Otherwise, our code would need to dig down to using the token store implementation directly, which seems an unpleasant violation of encapsulation.
