### PR TITLE
Add the ability to support grant_type password without client_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,17 @@ Token handler comes with defaults that use the various built in token, user etc.
                 :auth-code-lookup clauth.auth-code/fetch-auth-code })
 ```
 
+### Browser-based and mobile apps
+
+As described in [OAuth 2 Simplified](http://aaronparecki.com/articles/2012/07/29/1/oauth2-simplified),
+apps running in a browser or on a mobile device cannot maintain the confidentiality of the client
+secret, so you can allow these apps to skip client authentication when using a grant type of
+password by passing `:implicit-client` to `token-handler` as follows:
+
+```clojure
+(token-handler {:implicit-client clauth.client/implicit-client})
+```
+
 ## Using as primary user authentication on server
 
 One of the ideas of this is using OAuth tokens together with traditional sessions based authentication providing the benefits of both. To do this we create a new token when a user logs in and adds it to the session.

--- a/src/clauth/client.clj
+++ b/src/clauth/client.clj
@@ -48,3 +48,9 @@
   (if-let [client (fetch-client client-id)]
     (if (= client-secret (:client-secret client))
       client)))
+
+(defn implicit-client
+  "Fetch a client without authenticating using the client-secret. This is used for implicit
+  authorization."
+  [client-id client-secret]
+  (fetch-client client-id))

--- a/src/clauth/endpoints.clj
+++ b/src/clauth/endpoints.clj
@@ -114,10 +114,10 @@
         (error-response "invalid_grant")))))
 
  (defmethod token-request-handler "password"
-   [req {:keys [client-authenticator token-creator user-authenticator]}]
+   [req {:keys [client-authenticator token-creator user-authenticator implicit-client]}]
    (client-authenticated-request
     req
-    client-authenticator
+    (or implicit-client client-authenticator)
     (fn [req client] (if-let [user (user-authenticator
                                     ((req :params) :username)
                                     ((req :params) :password))]


### PR DESCRIPTION
This is based on http://aaronparecki.com/articles/2012/07/29/1/oauth2-simplified and discussed in #12.

@pelle, let me know what you think of this. I'm happy to tweak the interface if there's anything about it that doesn't feel right to you.
