### PR TITLE
minor typo fix

### DIFF
--- a/src/clauth/endpoints.clj
+++ b/src/clauth/endpoints.clj
@@ -160,7 +160,7 @@
 
 
 (defn return-to-handler
-  "Return to value of :return-to key session or the contents of defaukt-destination (by default '/')"
+  "Return to value of :return-to key session or the contents of default-destination (by default '/')"
   ([req]
     (return-to-handler req "/"))
 


### PR DESCRIPTION
Just noticed a typo in the docstring of return-to-handler.
