### PR TITLE
get redirect-uri correctly in authorization form

### DIFF
--- a/src/clauth/views.clj
+++ b/src/clauth/views.clj
@@ -52,7 +52,7 @@
                  [:div {:class "form-actions"}
                   [:button {:type "submit" :class "btn btn-primary"}
                    "Authorize"]
-                  [:a {:class "btn" :href (or ((req :params) "redirect_uri")
+                  [:a {:class "btn" :href (or ((req :params) :redirect_uri)
                                               "/")} "Cancel"]])))))
 
 (defn authorization-form-handler


### PR DESCRIPTION
wrap-keyword-params converts redirect_uri to a keyword, so that's how it
should be accessed.
