### PR TITLE
Configurable login url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /target
 
 .lein-repl-history
+.idea
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .lein-repl-history
 .idea
 *.iml
+*pom.xml.asc

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clauth "1.0.0-rc17"
+(defproject johncowie/clauth "1.0.1"
   :description "OAuth2 based authentication library for Ring"
   :url "http://github.com/pelle/clauth"
   :dependencies [[org.clojure/clojure "1.5.1"]
@@ -15,5 +15,7 @@
                      [lein-marginalia "0.7.0"]
                      [com.taoensso/carmine "2.2.0"]
                      [hiccup-bootstrap "0.1.0"]]}}
-  :clean-non-project-classes true )
+  :clean-non-project-classes true 
+  :scm {:name "git"
+	:url "https://github.com/johncowie/clauth"})
 

--- a/src/clauth/endpoints.clj
+++ b/src/clauth/endpoints.clj
@@ -287,7 +287,8 @@
   ([]
      (authorization-handler {}))
   ([config]
-     (let [config (merge {:authorization-form views/authorization-form-handler
+     (let [config (merge {:user-session-required-redirect "/login"
+                          :authorization-form views/authorization-form-handler
                           :client-lookup clauth.client/fetch-client
                           :token-lookup clauth.token/find-valid-token
                           :token-creator clauth.token/create-token
@@ -313,4 +314,5 @@
                    (authorization-error-response req "unsupported_response_type")))
                (authorization-error-response req "unauthorized_client"))
              (authorization-error-response req "invalid_request"))))
-        (:token-lookup config)))))
+        (:token-lookup config)
+        (:user-session-required-redirect config)))))

--- a/src/clauth/middleware.clj
+++ b/src/clauth/middleware.clj
@@ -183,9 +183,9 @@
 
 (defn user-session-required-response
   "Return HTTP 403 Response or redirects to login"
-  [req]
+  [req user-session-required-redirect]
   (if-html req
-           (-> (redirect "/login")
+           (-> (redirect user-session-required-redirect)
                (assoc-session req :return-to (requested-uri req)))
            {:status 403
             :headers {"Content-Type" "text/plain"}
@@ -204,11 +204,11 @@
 
    Will redirect user to login url if not authenticated and issue a 403 to
    other requests."
-  ([app]
-     (require-user-session! app token/find-valid-token))
-  ([app find-token]
+  ([app user-session-required-redirect]
+     (require-user-session! app token/find-valid-token user-session-required-redirect))
+  ([app find-token user-session-required-redirect]
      (wrap-user-session
       (fn [req]
         (if (req :access-token)
           (app req)
-          (user-session-required-response req))) find-token)))
+          (user-session-required-response req user-session-required-redirect))) find-token)))

--- a/test/clauth/test/middleware.clj
+++ b/test/clauth/test/middleware.clj
@@ -123,11 +123,11 @@
 (deftest require-user-session
   (is (= 200 (:status
               ((base/require-user-session!
-                (fn [req] {:status 200}) #{"secrettoken"})
+                (fn [req] {:status 200}) #{"secrettoken"} "/login")
                {:session {:access_token "secrettoken"}}))) "allow from session")
 
   (let [response ((base/require-user-session!
-                   (fn [req] {:status 200}) #{"secrettoken"})
+                   (fn [req] {:status 200}) #{"secrettoken"} "/login")
                   {:headers {"accept" "text/html"}
                    :query-string "test=123"
                    :uri "/protected"})]
@@ -136,19 +136,26 @@
     (is (= "/protected?test=123" ((:session response) :return-to))
         "set return-to"))
 
+  (let [response ((base/require-user-session!
+                    (fn [req] {:status 200}) #{"secrettoken"} "/different-login-page")
+                   {:headers {"accept" "text/html"}
+                    :query-string "test=123"
+                    :uri "/protected"})]
+    (is (= "/different-login-page" ((:headers response) "Location")) "login url is configurable"))
+
   (is (= 403 (:status
               ((base/require-user-session!
-                (fn [req] {:status 200}) #{"secrettoken"})
+                (fn [req] {:status 200}) #{"secrettoken"} "/login")
                {:headers {"authorization" "Bearer secrettoken"}})))
       "Disallow from auth header")
   (is (= 403 (:status
               ((base/require-user-session!
-                (fn [req] {:status 200}) #{"secrettoken"})
+                (fn [req] {:status 200}) #{"secrettoken"} "/login")
                {:cookies {"access_token" {:value "secrettoken"}}})))
       "Disallow from cookies")
   (is (= 403 (:status
               ((base/require-user-session!
-                (fn [req] {:status 200}) #{"secrettoken"})
+                (fn [req] {:status 200}) #{"secrettoken"} "/login")
                {:params {:access_token "secrettoken"}})))
       "Disallow from params"))
 


### PR DESCRIPTION
At present when arriving at the authorisation endpoint, if the user doesn't yet have a session then they are redirected to `/login` (this value is hardcoded).  

I've made a modification so that this value is configurable (and defaults to `/login`)
