### PR TITLE
Update dependencies, especially jBCrypt.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,18 +2,18 @@
   :description "OAuth2 based authentication library for Ring"
   :url "http://github.com/pelle/clauth"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [crypto-random "1.1.0"]
-                 [commons-codec "1.6"]
-                 [ring/ring-core "1.2.0"]
-                 [cheshire "5.2.0"]
-                 [clj-time "0.6.0"]
-                 [org.mindrot/jbcrypt "0.3m"]
-                 [hiccup "1.0.4"]]
+                 [crypto-random "1.2.0"]
+                 [commons-codec "1.10"]
+                 [ring/ring-core "1.4.0"]
+                 [cheshire "5.5.0"]
+                 [clj-time "0.11.0"]
+                 [de.svenkubiak/jBCrypt "0.4.1"]
+                 [hiccup "1.0.5"]]
 
   :profiles {:dev {
-                   :dependencies [[ring/ring-jetty-adapter "1.1.0"]
-                     [lein-marginalia "0.7.0"]
-                     [com.taoensso/carmine "2.2.0"]
-                     [hiccup-bootstrap "0.1.0"]]}}
+                   :dependencies [[ring/ring-jetty-adapter "1.4.0"]
+                     [lein-marginalia "0.8.0"]
+                     [com.taoensso/carmine "2.12.2"]
+                     [hiccup-bootstrap "0.1.2"]]}}
   :clean-non-project-classes true )
 


### PR DESCRIPTION
jBCrypt-0.4 fixes an integer overflow which occurs with very large
log_rounds values. In order to incorporate that fix, I had to switch to
a different Maven artifact which tracks more recent releases of
jBCrypt.

While updating that, I updated the other dependencies (apart from
Clojure itself). If you would like to update those separately, I can
certainly understand that. Alternately, you may want to update Clojure
as well, now that the final release of 1.8 is out.
